### PR TITLE
Additions to Codex Hugo Theme

### DIFF
--- a/exampleSite/content/blog/markdown-syntax.md
+++ b/exampleSite/content/blog/markdown-syntax.md
@@ -84,7 +84,7 @@ html
     </html>
 
 #### Code block with Hugo's internal highlight shortcode
-{{< highlight html >}}
+```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -95,7 +95,7 @@ html
   <p>Test</p>
 </body>
 </html>
-{{< /highlight >}}
+```
 
 ## List Types
 

--- a/exampleSite/content/blog/markdown-syntax.md
+++ b/exampleSite/content/blog/markdown-syntax.md
@@ -1,0 +1,130 @@
+---
+title: "Markdown Syntax Guide"
+date: 2020-06-05
+slug: "markdown-syntax-guide"
+description: "Sample article showcasing basic Markdown syntax and formatting for HTML elements"
+keywords: ["gohugo", "hugo", "go", "blog"]
+draft: false
+tags: ["markdown", "css", "html", "themes"]
+stylesheet: "post.css"
+---
+
+This article offers a sample of basic Markdown syntax that can be used in Hugo content files, also it shows whether basic HTML elements are decorated with CSS in a Hugo theme.
+<!--more-->
+
+## Headings
+
+The following HTML `<h1>`—`<h6>` elements represent six levels of section headings. `<h1>` is the highest section level while `<h6>` is the lowest.
+
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+
+## Paragraph
+
+Xerum, quo qui aut unt expliquam qui dolut labo. Aque venitatiusda cum, voluptionse latur sitiae dolessi aut parist aut dollo enim qui voluptate ma dolestendit peritin re plis aut quas inctum laceat est volestemque commosa as cus endigna tectur, offic to cor sequas etum rerum idem sintibus eiur? Quianimin porecus evelectur, cum que nis nust voloribus ratem aut omnimi, sitatur? Quiatem. Nam, omnis sum am facea corem alique molestrunt et eos evelece arcillit ut aut eos eos nus, sin conecerem erum fuga. Ri oditatquam, ad quibus unda veliamenimin cusam et facea ipsamus es exerum sitate dolores editium rerore eost, temped molorro ratiae volorro te reribus dolorer sperchicium faceata tiustia prat.
+
+Itatur? Quiatae cullecum rem ent aut odis in re eossequodi nonsequ idebis ne sapicia is sinveli squiatum, core et que aut hariosam ex eat.
+
+## Blockquotes
+
+The blockquote element represents content that is quoted from another source, optionally with a citation which must be within a `footer` or `cite` element, and optionally with in-line changes such as annotations and abbreviations.
+
+#### Blockquote without attribution
+
+> Tiam, ad mint andaepu dandae nostion secatur sequo quae.
+> **Note** that you can use *Markdown syntax* within a blockquote.
+
+## Tables
+
+Tables aren't part of the core Markdown spec, but Hugo supports supports them out-of-the-box.
+
+   Name | Age
+--------|------
+    Bob | 27
+  Alice | 23
+
+#### Inline Markdown within tables
+
+| Inline&nbsp;&nbsp;&nbsp;     | Markdown&nbsp;&nbsp;&nbsp;  | In&nbsp;&nbsp;&nbsp;                | Table      |
+| ---------- | --------- | ----------------- | ---------- |
+| *italics*  | **bold**  | ~~strikethrough~~&nbsp;&nbsp;&nbsp; | `code`     |
+
+## Code Blocks
+
+#### Code block with backticks
+
+```
+html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Example HTML5 Document</title>
+</head>
+<body>
+  <p>Test</p>
+</body>
+</html>
+```
+#### Code block indented with four spaces
+
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <title>Example HTML5 Document</title>
+    </head>
+    <body>
+      <p>Test</p>
+    </body>
+    </html>
+
+#### Code block with Hugo's internal highlight shortcode
+{{< highlight html >}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Example HTML5 Document</title>
+</head>
+<body>
+  <p>Test</p>
+</body>
+</html>
+{{< /highlight >}}
+
+## List Types
+
+#### Ordered List
+
+1. First item
+2. Second item
+3. Third item
+
+#### Unordered List
+
+* List item
+* Another item
+* And another item
+
+#### Nested list
+
+* Item
+1. First Sub-item
+2. Second Sub-item
+
+## Other Elements — abbr, sub, sup, kbd, mark
+
+<abbr title="Graphics Interchange Format">GIF</abbr> is a bitmap image format.
+
+H<sub>2</sub>O
+
+X<sup>n</sup> + Y<sup>n</sup> = Z<sup>n</sup>
+
+Press <kbd><kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>Delete</kbd></kbd> to end the session.
+
+Most <mark>salamanders</mark> are nocturnal, and hunt for insects, worms, and other small creatures.

--- a/exampleSite/content/blog/math-typesetting.md
+++ b/exampleSite/content/blog/math-typesetting.md
@@ -1,0 +1,48 @@
+---
+title: "Math Typesetting"
+date: 2020-06-05
+slug: "math-typesetting"
+description: "A brief guide to setup KaTeX"
+keywords: ["gohugo", "hugo", "go", "blog"]
+draft: false
+tags: ["math"]
+stylesheet: "post.css"
+math: true
+---
+
+Mathematical notation in a Hugo project can be enabled by using third party JavaScript libraries.
+<!--more-->
+
+In this example we will be using [KaTeX](https://katex.org/)
+
+- Create a partial under `/layouts/partials/math.html`
+- Within this partial reference the [Auto-render Extension](https://katex.org/docs/autorender.html) or host these scripts locally.
+- Include the partial in your templates like so:  
+
+```
+{{ if or .Params.math .Site.Params.math }}
+{{ partial "math.html" . }}
+{{ end }}
+```  
+- To enable KaTex globally set the parameter `math` to `true` in a project's configuration
+- To enable KaTex on a per page basis include the parameter `math: true` in content files.
+
+**Note:** Use the online reference of [Supported TeX Functions](https://katex.org/docs/supported.html)
+{{< math.inline >}}
+{{ if or .Page.Params.math .Site.Params.math }}
+<!-- KaTeX -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.js" integrity="sha384-2BKqo+exmr9su6dir+qCw08N2ZKRucY4PrGQPPWU1A7FtlCGjmEGFqXCv5nyM5Ij" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
+{{ end }}
+{{</ math.inline >}}
+
+### Examples
+
+Inline math: $$ \varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887… $$
+
+Block math:
+
+$$
+\sigma(t) = \cfrac{1}{1 + e^{-t}}
+$$

--- a/exampleSite/content/blog/rich-content.md
+++ b/exampleSite/content/blog/rich-content.md
@@ -1,0 +1,31 @@
+---
+title: "Rich Content"
+date: 2020-06-05
+slug: "rich-text"
+description: "A brief description of Hugo Shortcodes"
+keywords: ["gohugo", "hugo", "go", "blog"]
+draft: false
+tags: ["shortcodes"]
+stylesheet: "post.css"
+---
+
+Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
+
+## Instagram Simple Shortcode
+
+{{< instagram_simple BGvuInzyFAe hidecaption >}}
+
+
+## YouTube Privacy Enhanced Shortcode
+
+{{< youtube ZJthWmvUzzc >}}
+
+
+## Twitter Simple Shortcode
+
+{{< tweet 1085870671291310081 >}}
+
+
+## Vimeo Simple Shortcode
+
+{{< vimeo_simple 48912912 >}}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -13,6 +13,9 @@
   </header>
   <article class="post__content">
     {{ partial "anchored-headings.html" .Content }}
+    {{ if or .Params.math .Site.Params.math }}
+      {{ partial "math.html" . }}
+    {{ end }}
   </article>
   {{ partial "tags.html" .}} {{ partial "post-pagination.html" .}}
 </div>

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,0 +1,11 @@
+<!-- layouts/partials/math.html -->
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_SVG"></script>
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+            showMathMenu: false, //disables context menu
+            tex2jax: {
+            inlineMath: [ ['$','$'], ['\\(','\\)'] ]
+           }
+    });
+</script>

--- a/src/styles/pages/post.styl
+++ b/src/styles/pages/post.styl
@@ -175,7 +175,7 @@ p.warning
 footer
   text-align: center
   padding: 0 1.5rem
-  background: #F6F9FC
+  background: #ffffff
 
   p
     color: $grey

--- a/static/css/about.css
+++ b/static/css/about.css
@@ -1,1 +1,433 @@
-button,button[type="button"],button[type="reset"],button[type="submit"]{-webkit-appearance:button}input,input[type=text],input[type=email]{-webkit-appearance:none;-moz-appearance:none;appearance:none}html,body{background-color:#fff;color:#111;height:100%}html{-webkit-box-sizing:border-box;box-sizing:border-box}*,*:before,*:after{padding:0;margin:0;-webkit-box-sizing:inherit;box-sizing:inherit}html{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;-webkit-font-smoothing:antialiased;font-size:95%;}@media screen and (min-width:800px){html{font-size:100%}}@media screen and (min-width:1400px){html{font-size:115%}}h1,h2,h3,h4,h5,h6{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem;}h1{font-size:2.121rem;line-height:2.25rem;margin-top:2.25rem}h2{font-size:1.414rem}h3{font-size:1.414/2rem}h4{font-size:1.414/3rem}h5{font-size:1.414/4rem}p{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem}ul,ol{padding-left:1.5rem;margin-top:1.5rem;margin-bottom:1.5rem;}ul li,ol li{line-height:1.5rem}ul ul,ol ul,ul ol,ol ol{margin-top:0;margin-bottom:0}blockquote{margin-top:1.5rem;margin-bottom:1.5rem;line-height:1.5rem;color:#717171;font-style:italic}pre{line-height:1.45;margin-top:1.5rem;padding:16px;word-wrap:normal;overflow:auto;background-color:#f6f8fa;border-radius:3px}code{font-size:85%;font-family:"SFMono-Regular",Consolas,Menlo,monospace;padding:.2em .4em;margin:0;background-color:rgba(27,31,35,0.05);border-radius:3px}pre>code{word-break:normal;white-space:pre}pre code{display:inline;padding:0;margin:0;overflow:visible;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}.lead{font-size:1.414rem}.burger__container{height:4rem;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding:0 1.5rem;position:fixed;width:100%;background:#fff;z-index:2;}@media screen and (min-width:800px){.burger__container{display:none}}.burger{position:relative;width:28px;height:28px;cursor:pointer}.burger__meat{position:absolute;width:28px;height:2px;background:#111;top:calc(50% - 2px / 2);left:calc(50% - 28px / 2);-webkit-transition:all 150ms ease-in;transition:all 150ms ease-in}.burger__meat--1{-webkit-transform:translateY(-10px);transform:translateY(-10px)}.burger__meat--2{width:calc(28px - 6px)}.burger__meat--3{-webkit-transform:translateY(10px);transform:translateY(10px)}.nav--active .burger__meat--1{-webkit-transform:rotate(45deg);transform:rotate(45deg)}.nav--active .burger__meat--2{opacity:0}.nav--active .burger__meat--3{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.nav{font-size:16px;position:fixed;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background:#fff;visibility:hidden;z-index:1;}@media screen and (min-width:800px){.nav{display:block;visibility:visible;padding-top:3em;width:100px}}.nav--active .nav{visibility:visible;height:100%;width:100%}.nav__list{text-align:right;list-style:none;margin:0;padding:0;width:50%;}@media screen and (min-width:800px){.nav__list{width:auto}}@media screen and (max-width:799px){.nav__list{-webkit-transform:translateY(-25px);transform:translateY(-25px);opacity:0}.nav--active .nav__list{-webkit-transform:translateY(0);transform:translateY(0);opacity:1;-webkit-transition:all 500ms ease;transition:all 500ms ease}}.nav__list li{margin-bottom:3em;line-height:1.5em;}.nav__list li:last-of-type{margin-bottom:0}@media screen and (min-width:800px){.nav__list li{margin-bottom:1.75em}}.nav__list a{color:#9b9b9b;text-decoration:none;font-size:2em;}.nav__list a.active{color:#111}.nav__list a:hover{color:#111}@media screen and (min-width:800px){.nav__list a{font-size:1em}}body.nav--active{overflow:hidden}main{padding:3rem 1.5rem;}@media screen and (min-width:800px){main{padding-left:calc(1.5rem + 100px)}}@media screen and (max-width:799px){main{padding-top:calc(3rem + 4rem)}}.social-icons{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.social-icons__icon{width:1.2rem;height:1.2rem;background-size:contain;background-repeat:no-repeat}.social-icons__icon--twitter{background-image:url("/icons/twitter.svg");margin-right:2rem}.social-icons__icon--github{background-image:url("/icons/github.svg")}.splash-container{height:100%;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;font-size:14px;}@media screen and (min-width:800px){.splash-container{font-size:18px}}.splash h1{font-size:3em;line-height:1;letter-spacing:-.03em;margin:0}.splash h2{font-size:2.25em;font-weight:500;line-height:1.25;max-width:22em;letter-spacing:-.03em}.fancy{color:#9013fe}.handle{display:inline-block;margin-top:.275em;color:#9b9b9b;letter-spacing:.5px}.writing{text-decoration:none;color:#9013fe}main{padding-top:0;padding-bottom:0;height:100%}.social-icons{-webkit-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;padding-top:2rem}
+button,
+button[type="button"],
+button[type="reset"],
+button[type="submit"] {
+  -webkit-appearance: button
+}
+
+input,
+input[type=text],
+input[type=email] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+html,
+body {
+  background-color: #fff;
+  color: #111;
+  height: 100%
+}
+
+html {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+}
+
+*,
+*:before,
+*:after {
+  padding: 0;
+  margin: 0;
+  -webkit-box-sizing: inherit;
+  box-sizing: inherit
+}
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 95%;
+}
+
+@media screen and (min-width:800px) {
+  html {
+    font-size: 100%
+  }
+}
+
+@media screen and (min-width:1400px) {
+  html {
+    font-size: 115%
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem;
+}
+
+h1 {
+  font-size: 2.121rem;
+  line-height: 2.25rem;
+  margin-top: 2.25rem
+}
+
+h2 {
+  font-size: 1.414rem
+}
+
+h3 {
+  font-size: 1.414/2rem
+}
+
+h4 {
+  font-size: 1.414/3rem
+}
+
+h5 {
+  font-size: 1.414/4rem
+}
+
+p {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem
+}
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+ul li,
+ol li {
+  line-height: 1.5rem
+}
+
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0
+}
+
+blockquote {
+  font-family: medium-content-title-font, Georgia, Cambria, "Times New Roman", Times, serif;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
+  color: #717171;
+  font-style: italic;
+}
+
+pre {
+  line-height: 1.45;
+  margin-top: 1.5rem;
+  padding: 16px;
+  word-wrap: normal;
+  overflow: auto;
+  background-color: #f6f8fa;
+  border-radius: 3px
+}
+
+code {
+  font-size: 85%;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: rgba(27, 31, 35, 0.05);
+  border-radius: 3px
+}
+
+pre>code {
+  word-break: normal;
+  white-space: pre
+}
+
+pre code {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0
+}
+
+.lead {
+  font-size: 1.414rem
+}
+
+.burger__container {
+  height: 4rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0 1.5rem;
+  position: fixed;
+  width: 100%;
+  background: #fff;
+  z-index: 2;
+}
+
+@media screen and (min-width:800px) {
+  .burger__container {
+    display: none
+  }
+}
+
+.burger {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  cursor: pointer
+}
+
+.burger__meat {
+  position: absolute;
+  width: 28px;
+  height: 2px;
+  background: #111;
+  top: calc(50% - 2px / 2);
+  left: calc(50% - 28px / 2);
+  -webkit-transition: all 150ms ease-in;
+  transition: all 150ms ease-in
+}
+
+.burger__meat--1 {
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.burger__meat--2 {
+  width: calc(28px - 6px)
+}
+
+.burger__meat--3 {
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.nav--active .burger__meat--1 {
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg)
+}
+
+.nav--active .burger__meat--2 {
+  opacity: 0
+}
+
+.nav--active .burger__meat--3 {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg)
+}
+
+.nav {
+  font-size: 16px;
+  position: fixed;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fff;
+  visibility: hidden;
+  z-index: 1;
+}
+
+@media screen and (min-width:800px) {
+  .nav {
+    display: block;
+    visibility: visible;
+    padding-top: 3em;
+    width: 100px
+  }
+}
+
+.nav--active .nav {
+  visibility: visible;
+  height: 100%;
+  width: 100%
+}
+
+.nav__list {
+  text-align: right;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+@media screen and (min-width:800px) {
+  .nav__list {
+    width: auto
+  }
+}
+
+@media screen and (max-width:799px) {
+  .nav__list {
+    -webkit-transform: translateY(-25px);
+    transform: translateY(-25px);
+    opacity: 0
+  }
+
+  .nav--active .nav__list {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+    -webkit-transition: all 500ms ease;
+    transition: all 500ms ease
+  }
+}
+
+.nav__list li {
+  margin-bottom: 3em;
+  line-height: 1.5em;
+}
+
+.nav__list li:last-of-type {
+  margin-bottom: 0
+}
+
+@media screen and (min-width:800px) {
+  .nav__list li {
+    margin-bottom: 1.75em
+  }
+}
+
+.nav__list a {
+  color: #9b9b9b;
+  text-decoration: none;
+  font-size: 2em;
+}
+
+.nav__list a.active {
+  color: #111
+}
+
+.nav__list a:hover {
+  color: #111
+}
+
+@media screen and (min-width:800px) {
+  .nav__list a {
+    font-size: 1em
+  }
+}
+
+body.nav--active {
+  overflow: hidden
+}
+
+main {
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width:800px) {
+  main {
+    padding-left: calc(1.5rem + 100px)
+  }
+}
+
+@media screen and (max-width:799px) {
+  main {
+    padding-top: calc(3rem + 4rem)
+  }
+}
+
+.social-icons {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center
+}
+
+.social-icons__icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  background-size: contain;
+  background-repeat: no-repeat
+}
+
+.social-icons__icon--twitter {
+  background-image: url("/icons/twitter.svg");
+  margin-right: 2rem
+}
+
+.social-icons__icon--github {
+  background-image: url("/icons/github.svg")
+}
+
+.splash-container {
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+}
+
+@media screen and (min-width:800px) {
+  .splash-container {
+    font-size: 18px
+  }
+}
+
+.splash h1 {
+  font-size: 3em;
+  line-height: 1;
+  letter-spacing: -.03em;
+  margin: 0
+}
+
+.splash h2 {
+  font-size: 2.25em;
+  font-weight: 500;
+  line-height: 1.25;
+  max-width: 22em;
+  letter-spacing: -.03em
+}
+
+.fancy {
+  color: #9013fe
+}
+
+.handle {
+  display: inline-block;
+  margin-top: .275em;
+  color: #9b9b9b;
+  letter-spacing: .5px
+}
+
+.writing {
+  text-decoration: none;
+  color: #9013fe
+}
+
+main {
+  padding-top: 0;
+  padding-bottom: 0;
+  height: 100%
+}
+
+.social-icons {
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding-top: 2rem
+}

--- a/static/css/post.css
+++ b/static/css/post.css
@@ -1,1 +1,869 @@
-button,button[type="button"],button[type="reset"],button[type="submit"]{-webkit-appearance:button}input,input[type=text],input[type=email]{-webkit-appearance:none;-moz-appearance:none;appearance:none}html,body{background-color:#fff;color:#111;height:100%}html{-webkit-box-sizing:border-box;box-sizing:border-box}*,*:before,*:after{padding:0;margin:0;-webkit-box-sizing:inherit;box-sizing:inherit}html{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;-webkit-font-smoothing:antialiased;font-size:95%;}@media screen and (min-width:800px){html{font-size:100%}}@media screen and (min-width:1400px){html{font-size:115%}}h1,h2,h3,h4,h5,h6{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem;}h1{font-size:2.121rem;line-height:2.25rem;margin-top:2.25rem}h2{font-size:1.414rem}h3{font-size:1.414/2rem}h4{font-size:1.414/3rem}h5{font-size:1.414/4rem}p{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem}ul,ol{padding-left:1.5rem;margin-top:1.5rem;margin-bottom:1.5rem;}ul li,ol li{line-height:1.5rem}ul ul,ol ul,ul ol,ol ol{margin-top:0;margin-bottom:0}blockquote{margin-top:1.5rem;margin-bottom:1.5rem;line-height:1.5rem;color:#717171;font-style:italic}pre{line-height:1.45;margin-top:1.5rem;padding:16px;word-wrap:normal;overflow:auto;background-color:#f6f8fa;border-radius:3px}code{font-size:85%;font-family:"SFMono-Regular",Consolas,Menlo,monospace;padding:.2em .4em;margin:0;background-color:rgba(27,31,35,0.05);border-radius:3px}pre>code{word-break:normal;white-space:pre}pre code{display:inline;padding:0;margin:0;overflow:visible;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}.lead{font-size:1.414rem}.burger__container{height:4rem;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding:0 1.5rem;position:fixed;width:100%;background:#fff;z-index:2;}@media screen and (min-width:800px){.burger__container{display:none}}.burger{position:relative;width:28px;height:28px;cursor:pointer}.burger__meat{position:absolute;width:28px;height:2px;background:#111;top:calc(50% - 2px / 2);left:calc(50% - 28px / 2);-webkit-transition:all 150ms ease-in;transition:all 150ms ease-in}.burger__meat--1{-webkit-transform:translateY(-10px);transform:translateY(-10px)}.burger__meat--2{width:calc(28px - 6px)}.burger__meat--3{-webkit-transform:translateY(10px);transform:translateY(10px)}.nav--active .burger__meat--1{-webkit-transform:rotate(45deg);transform:rotate(45deg)}.nav--active .burger__meat--2{opacity:0}.nav--active .burger__meat--3{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.nav{font-size:16px;position:fixed;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background:#fff;visibility:hidden;z-index:1;}@media screen and (min-width:800px){.nav{display:block;visibility:visible;padding-top:3em;width:100px}}.nav--active .nav{visibility:visible;height:100%;width:100%}.nav__list{text-align:right;list-style:none;margin:0;padding:0;width:50%;}@media screen and (min-width:800px){.nav__list{width:auto}}@media screen and (max-width:799px){.nav__list{-webkit-transform:translateY(-25px);transform:translateY(-25px);opacity:0}.nav--active .nav__list{-webkit-transform:translateY(0);transform:translateY(0);opacity:1;-webkit-transition:all 500ms ease;transition:all 500ms ease}}.nav__list li{margin-bottom:3em;line-height:1.5em;}.nav__list li:last-of-type{margin-bottom:0}@media screen and (min-width:800px){.nav__list li{margin-bottom:1.75em}}.nav__list a{color:#9b9b9b;text-decoration:none;font-size:2em;}.nav__list a.active{color:#111}.nav__list a:hover{color:#111}@media screen and (min-width:800px){.nav__list a{font-size:1em}}body.nav--active{overflow:hidden}main{padding:3rem 1.5rem;}@media screen and (min-width:800px){main{padding-left:calc(1.5rem + 100px)}}@media screen and (max-width:799px){main{padding-top:calc(3rem + 4rem)}}.social-icons{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center}.social-icons__icon{width:1.2rem;height:1.2rem;background-size:contain;background-repeat:no-repeat}.social-icons__icon--twitter{background-image:url("/icons/twitter.svg");margin-right:2rem}.social-icons__icon--github{background-image:url("/icons/github.svg")}code[class*="language-"],pre[class*="language-"]{color:#24292e;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-ms-hyphens:none;hyphens:none}.token.comment,.token.prolog,.token.doctype,.token.cdata,.token.plain-text{color:#6a737d}.token.atrule,.token.attr-value,.token.keyword,.token.operator{color:#d73a49}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color:#22863a}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color:#032f62}.token.function,.token.class-name{color:#6f42c1}.language-jsx .token.punctuation,.language-jsx .token.tag .token.punctuation,.language-jsx .token.tag .token.script,.language-jsx .token.plain-text{color:#24292e}.language-jsx .token.tag .token.attr-name{color:#6f42c1}.language-jsx .token.tag .token.class-name{color:#005cc5}.language-jsx .token.tag .token.script-punctuation,.language-jsx .token.attr-value .token.punctuation:first-child{color:#d73a49}.language-jsx .token.attr-value{color:#032f62}.language-jsx span.[class="comment"]{color:#ffc0cb}.language-html .token.tag .token.punctuation{color:#24292e}.language-html .token.tag .token.attr-name{color:#6f42c1}.language-html .token.tag .token.attr-value,.language-html .token.tag .token.attr-value .token.punctuation:not(:first-child){color:#032f62}.language-css .token.selector{color:#6f42c1}.language-css .token.property{color:#005cc5}.newsletter__container{padding:3rem 0}.newsletter__logo{text-align:center;}.newsletter__logo h2{font-weight:400;font-size:2.5rem;letter-spacing:-2px;text-transform:lowercase;margin:0;line-height:1.5;}.newsletter__logo h2 span{color:#9013fe}.newsletter__logo > span{font-weight:300;font-size:.9rem;text-transform:lowercase;color:#9b9b9b}.newsletter__subscribe-form{position:relative;max-width:450px;margin:3rem auto 0;padding-bottom:2rem;text-align:center}.newsletter__subscribe-form-inputs{margin-bottom:1.5rem;display:-webkit-box;display:-ms-flexbox;display:flex;}@media (max-width:499px){.newsletter__subscribe-form-inputs{-webkit-box-orient:vertical;-webkit-box-direction:normal;-ms-flex-direction:column;flex-direction:column}}.newsletter__subscribe-form-inputs--email{height:32px;color:#717171;border-radius:24px;margin-right:12px;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;padding:0 20px;border:1px solid #9b9b9b;font-size:1rem;}.newsletter__subscribe-form-inputs--email:focus{outline:none}.newsletter__subscribe-form-inputs--email::-webkit-input-placeholder{color:#9b9b9b}.newsletter__subscribe-form-inputs--email::-ms-input-placeholder{color:#9b9b9b}.newsletter__subscribe-form-inputs--email::placeholder{color:#9b9b9b}@media (max-width:499px){.newsletter__subscribe-form-inputs--email{margin-right:0;margin-bottom:1rem}}.newsletter__subscribe-form-inputs--submit{background:#9013fe;color:#fff;text-shadow:0 1px 3px rgba(36,180,126,0.4);height:32px;line-height:32px;-webkit-box-shadow:0 4px 6px rgba(50,50,93,0.11),0 1px 3px rgba(0,0,0,0.08);box-shadow:0 4px 6px rgba(50,50,93,0.11),0 1px 3px rgba(0,0,0,0.08);border:none;border-radius:24px;font-size:14px;padding:0 14px;text-transform:uppercase;letter-spacing:.025rem;-ms-flex-negative:0;flex-shrink:0;-webkit-transition:all 150ms ease;transition:all 150ms ease;}.newsletter__subscribe-form-inputs--submit:hover{cursor:pointer;-webkit-box-shadow:0 7px 14px rgba(50,50,93,0.1),0 3px 6px rgba(0,0,0,0.08);box-shadow:0 7px 14px rgba(50,50,93,0.1),0 3px 6px rgba(0,0,0,0.08);-webkit-transform:translateY(-1px);transform:translateY(-1px)}.newsletter__subscribe-form-inputs--submit:focus{outline:none}.newsletter__buttondown-link,.newsletter__learn-more{position:absolute;left:0;bottom:8px;right:0;color:#9b9b9b}.newsletter__buttondown-link{font-size:12px}.newsletter__learn-more{font-size:14px}.post{width:100%;max-width:34rem;margin:0 auto;}.post h2,.post h3{position:relative;padding-top:10px;}.post h2 .anchor,.post h3 .anchor{text-decoration:none;position:absolute;left:-1rem;color:#9b9b9b;font-size:1.2rem;font-weight:400}.post h2 .anchor:hover,.post h3 .anchor:hover{color:#717171}.post blockquote{width:95%;margin:0 auto;font-size:1rem;}.post blockquote a{color:#717171;text-decoration:underline}.post img{width:100%;max-width:500px;margin:0 auto;display:block}.post__content a{font-weight:400;color:#0366d6;text-decoration:none;}.post__content a:hover{text-decoration:underline}.post__title{margin-top:0;margin-bottom:.5rem}.post__date{color:#9b9b9b;font-size:.8rem}.cp_embed_wrapper{margin-top:1.5rem}.codepen__caption{display:block;width:75%;margin:.5rem auto 0;color:#9b9b9b;font-size:.8rem;font-weight:300;text-align:center}.note{width:90%;margin:1rem auto 0;font-size:12px;text-align:center;line-height:1.5;color:#9b9b9b;}.note code{font-size:12px;color:#717171;background-color:transparent;}.note code:before,.note code:after{content:'`'}.note a{color:#717171;text-decoration:underline}.tags__list{padding-right:1.5rem;margin:1.5rem 0 0;list-style:none;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:end;-ms-flex-pack:end;justify-content:flex-end}.tag__item{margin-right:1rem;display:inline-block;}.tag__item:last-child{margin-right:0}.tag__link{display:inline-block;text-decoration:none;padding:.2em .4em;border-radius:3px;background:#f4e7ff;color:#9013fe;font-size:.8rem;}.tag__link:hover{background:#ead2ff}.gif{margin-top:1.5rem;}.gif img{max-width:375px}p.warning{background:#fff9df;padding:1rem;font-size:.8rem;line-height:1.5;color:#747160;border-left:2px solid #747160;}p.warning a{color:#747160;text-decoration:underline}.pagination{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-ms-flex-direction:column;flex-direction:column;margin-top:1.5rem;}@media screen and (min-width:600px){.pagination{-webkit-box-orient:horizontal;-webkit-box-direction:normal;-ms-flex-direction:row;flex-direction:row;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between}}.pagination__item{text-decoration:none;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-ms-flex-direction:column;flex-direction:column;}.pagination__item:nth-child(2){margin-top:1.5rem}@media screen and (min-width:600px){.pagination__item{width:275px;padding:15px;border-radius:4px}.pagination__item:first-of-type{padding-right:15px}.pagination__item:last-of-type{margin-top:0}.pagination__item:hover{background-color:#f6f9fc}}.pagination__label{color:#9b9b9b;font-size:.8rem}.pagination__title{color:#111;font-weight:700;margin-top:.25rem}footer{text-align:center;padding:0 1.5rem;background:#f6f9fc;}footer p{color:#9b9b9b;font-size:.65rem}.post__content ul{list-style:none;}.post__content ul li{margin-bottom:.5rem;}.post__content ul li::before{content:'-';color:#717171;position:absolute;margin-left:-15px}.twitter-tweet.twitter-tweet-rendered{margin:1.5rem auto !important;width:375px !important}.newsletter__buttondown-link{display:none}
+button,
+button[type="button"],
+button[type="reset"],
+button[type="submit"] {
+  -webkit-appearance: button
+}
+
+input,
+input[type=text],
+input[type=email] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+html,
+body {
+  background-color: #fff;
+  color: #111;
+  height: 100%
+}
+
+html {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+}
+
+*,
+*:before,
+*:after {
+  padding: 0;
+  margin: 0;
+  -webkit-box-sizing: inherit;
+  box-sizing: inherit
+}
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 95%;
+}
+
+@media screen and (min-width:800px) {
+  html {
+    font-size: 100%
+  }
+}
+
+@media screen and (min-width:1400px) {
+  html {
+    font-size: 115%
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem;
+}
+
+h1 {
+  font-size: 2.121rem;
+  line-height: 2.25rem;
+  margin-top: 2.25rem
+}
+
+h2 {
+  font-size: 1.414rem
+}
+
+h3 {
+  font-size: 1.414/2rem
+}
+
+h4 {
+  font-size: 1.414/3rem
+}
+
+h5 {
+  font-size: 1.414/4rem
+}
+
+p {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem
+}
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+ul li,
+ol li {
+  line-height: 1.5rem
+}
+
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0
+}
+
+blockquote {
+  font-family: medium-content-title-font, Georgia, Cambria, "Times New Roman", Times, serif;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
+  color: #717171;
+  font-style: italic;
+}
+
+pre {
+  line-height: 1.45;
+  margin-top: 1.5rem;
+  padding: 16px;
+  word-wrap: normal;
+  overflow: auto;
+  background-color: #f6f8fa;
+  border-radius: 3px
+}
+
+code {
+  font-size: 85%;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: rgba(27, 31, 35, 0.05);
+  border-radius: 3px
+}
+
+pre>code {
+  word-break: normal;
+  white-space: pre
+}
+
+pre code {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0
+}
+
+.lead {
+  font-size: 1.414rem
+}
+
+.burger__container {
+  height: 4rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0 1.5rem;
+  position: fixed;
+  width: 100%;
+  background: #fff;
+  z-index: 2;
+}
+
+@media screen and (min-width:800px) {
+  .burger__container {
+    display: none
+  }
+}
+
+.burger {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  cursor: pointer
+}
+
+.burger__meat {
+  position: absolute;
+  width: 28px;
+  height: 2px;
+  background: #111;
+  top: calc(50% - 2px / 2);
+  left: calc(50% - 28px / 2);
+  -webkit-transition: all 150ms ease-in;
+  transition: all 150ms ease-in
+}
+
+.burger__meat--1 {
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.burger__meat--2 {
+  width: calc(28px - 6px)
+}
+
+.burger__meat--3 {
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.nav--active .burger__meat--1 {
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg)
+}
+
+.nav--active .burger__meat--2 {
+  opacity: 0
+}
+
+.nav--active .burger__meat--3 {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg)
+}
+
+.nav {
+  font-size: 16px;
+  position: fixed;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fff;
+  visibility: hidden;
+  z-index: 1;
+}
+
+@media screen and (min-width:800px) {
+  .nav {
+    display: block;
+    visibility: visible;
+    padding-top: 3em;
+    width: 100px
+  }
+}
+
+.nav--active .nav {
+  visibility: visible;
+  height: 100%;
+  width: 100%
+}
+
+.nav__list {
+  text-align: right;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+@media screen and (min-width:800px) {
+  .nav__list {
+    width: auto
+  }
+}
+
+@media screen and (max-width:799px) {
+  .nav__list {
+    -webkit-transform: translateY(-25px);
+    transform: translateY(-25px);
+    opacity: 0
+  }
+
+  .nav--active .nav__list {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+    -webkit-transition: all 500ms ease;
+    transition: all 500ms ease
+  }
+}
+
+.nav__list li {
+  margin-bottom: 3em;
+  line-height: 1.5em;
+}
+
+.nav__list li:last-of-type {
+  margin-bottom: 0
+}
+
+@media screen and (min-width:800px) {
+  .nav__list li {
+    margin-bottom: 1.75em
+  }
+}
+
+.nav__list a {
+  color: #9b9b9b;
+  text-decoration: none;
+  font-size: 2em;
+}
+
+.nav__list a.active {
+  color: #111
+}
+
+.nav__list a:hover {
+  color: #111
+}
+
+@media screen and (min-width:800px) {
+  .nav__list a {
+    font-size: 1em
+  }
+}
+
+body.nav--active {
+  overflow: hidden
+}
+
+main {
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width:800px) {
+  main {
+    padding-left: calc(1.5rem + 100px)
+  }
+}
+
+@media screen and (max-width:799px) {
+  main {
+    padding-top: calc(3rem + 4rem)
+  }
+}
+
+.social-icons {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center
+}
+
+.social-icons__icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  background-size: contain;
+  background-repeat: no-repeat
+}
+
+.social-icons__icon--twitter {
+  background-image: url("/icons/twitter.svg");
+  margin-right: 2rem
+}
+
+.social-icons__icon--github {
+  background-image: url("/icons/github.svg")
+}
+
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #24292e;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata,
+.token.plain-text {
+  color: #6a737d
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword,
+.token.operator {
+  color: #d73a49
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #22863a
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #032f62
+}
+
+.token.function,
+.token.class-name {
+  color: #6f42c1
+}
+
+.language-jsx .token.punctuation,
+.language-jsx .token.tag .token.punctuation,
+.language-jsx .token.tag .token.script,
+.language-jsx .token.plain-text {
+  color: #24292e
+}
+
+.language-jsx .token.tag .token.attr-name {
+  color: #6f42c1
+}
+
+.language-jsx .token.tag .token.class-name {
+  color: #005cc5
+}
+
+.language-jsx .token.tag .token.script-punctuation,
+.language-jsx .token.attr-value .token.punctuation:first-child {
+  color: #d73a49
+}
+
+.language-jsx .token.attr-value {
+  color: #032f62
+}
+
+.language-jsx span.[class="comment"] {
+  color: #ffc0cb
+}
+
+.language-html .token.tag .token.punctuation {
+  color: #24292e
+}
+
+.language-html .token.tag .token.attr-name {
+  color: #6f42c1
+}
+
+.language-html .token.tag .token.attr-value,
+.language-html .token.tag .token.attr-value .token.punctuation:not(:first-child) {
+  color: #032f62
+}
+
+.language-css .token.selector {
+  color: #6f42c1
+}
+
+.language-css .token.property {
+  color: #005cc5
+}
+
+.newsletter__container {
+  padding: 3rem 0
+}
+
+.newsletter__logo {
+  text-align: center;
+}
+
+.newsletter__logo h2 {
+  font-weight: 400;
+  font-size: 2.5rem;
+  letter-spacing: -2px;
+  text-transform: lowercase;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.newsletter__logo h2 span {
+  color: #9013fe
+}
+
+.newsletter__logo>span {
+  font-weight: 300;
+  font-size: .9rem;
+  text-transform: lowercase;
+  color: #9b9b9b
+}
+
+.newsletter__subscribe-form {
+  position: relative;
+  max-width: 450px;
+  margin: 3rem auto 0;
+  padding-bottom: 2rem;
+  text-align: center
+}
+
+.newsletter__subscribe-form-inputs {
+  margin-bottom: 1.5rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+@media (max-width:499px) {
+  .newsletter__subscribe-form-inputs {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column
+  }
+}
+
+.newsletter__subscribe-form-inputs--email {
+  height: 32px;
+  color: #717171;
+  border-radius: 24px;
+  margin-right: 12px;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  padding: 0 20px;
+  border: 1px solid #9b9b9b;
+  font-size: 1rem;
+}
+
+.newsletter__subscribe-form-inputs--email:focus {
+  outline: none
+}
+
+.newsletter__subscribe-form-inputs--email::-webkit-input-placeholder {
+  color: #9b9b9b
+}
+
+.newsletter__subscribe-form-inputs--email::-ms-input-placeholder {
+  color: #9b9b9b
+}
+
+.newsletter__subscribe-form-inputs--email::placeholder {
+  color: #9b9b9b
+}
+
+@media (max-width:499px) {
+  .newsletter__subscribe-form-inputs--email {
+    margin-right: 0;
+    margin-bottom: 1rem
+  }
+}
+
+.newsletter__subscribe-form-inputs--submit {
+  background: #9013fe;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(36, 180, 126, 0.4);
+  height: 32px;
+  line-height: 32px;
+  -webkit-box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
+  border: none;
+  border-radius: 24px;
+  font-size: 14px;
+  padding: 0 14px;
+  text-transform: uppercase;
+  letter-spacing: .025rem;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: all 150ms ease;
+  transition: all 150ms ease;
+}
+
+.newsletter__subscribe-form-inputs--submit:hover {
+  cursor: pointer;
+  -webkit-box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
+  -webkit-transform: translateY(-1px);
+  transform: translateY(-1px)
+}
+
+.newsletter__subscribe-form-inputs--submit:focus {
+  outline: none
+}
+
+.newsletter__buttondown-link,
+.newsletter__learn-more {
+  position: absolute;
+  left: 0;
+  bottom: 8px;
+  right: 0;
+  color: #9b9b9b
+}
+
+.newsletter__buttondown-link {
+  font-size: 12px
+}
+
+.newsletter__learn-more {
+  font-size: 14px
+}
+
+.post {
+  width: 100%;
+  max-width: 34rem;
+  margin: 0 auto;
+}
+
+.post h2,
+.post h3 {
+  position: relative;
+  padding-top: 10px;
+}
+
+.post h2 .anchor,
+.post h3 .anchor {
+  text-decoration: none;
+  position: absolute;
+  left: -1rem;
+  color: #9b9b9b;
+  font-size: 1.2rem;
+  font-weight: 400
+}
+
+.post h2 .anchor:hover,
+.post h3 .anchor:hover {
+  color: #717171
+}
+
+.post blockquote {
+  width: 95%;
+  margin: 0 auto;
+  font-size: 1rem;
+}
+.post blockquote a {
+  color: #717171;
+  text-decoration: underline;
+}
+
+.post img {
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
+  display: block
+}
+
+.post__content a {
+  font-weight: 400;
+  color: #0366d6;
+  text-decoration: none;
+}
+
+.post__content a:hover {
+  text-decoration: underline
+}
+
+.post__title {
+  margin-top: 0;
+  margin-bottom: .5rem
+}
+
+.post__date {
+  color: #9b9b9b;
+  font-size: .8rem
+}
+
+.cp_embed_wrapper {
+  margin-top: 1.5rem
+}
+
+.codepen__caption {
+  display: block;
+  width: 75%;
+  margin: .5rem auto 0;
+  color: #9b9b9b;
+  font-size: .8rem;
+  font-weight: 300;
+  text-align: center
+}
+
+.note {
+  width: 90%;
+  margin: 1rem auto 0;
+  font-size: 12px;
+  text-align: center;
+  line-height: 1.5;
+  color: #9b9b9b;
+}
+
+.note code {
+  font-size: 12px;
+  color: #717171;
+  background-color: transparent;
+}
+
+.note code:before,
+.note code:after {
+  content: '`'
+}
+
+.note a {
+  color: #717171;
+  text-decoration: underline
+}
+
+.tags__list {
+  padding-right: 1.5rem;
+  margin: 1.5rem 0 0;
+  list-style: none;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end
+}
+
+.tag__item {
+  margin-right: 1rem;
+  display: inline-block;
+}
+
+.tag__item:last-child {
+  margin-right: 0
+}
+
+.tag__link {
+  display: inline-block;
+  text-decoration: none;
+  padding: .2em .4em;
+  border-radius: 3px;
+  background: #f4e7ff;
+  color: #9013fe;
+  font-size: .8rem;
+}
+
+.tag__link:hover {
+  background: #ead2ff
+}
+
+.gif {
+  margin-top: 1.5rem;
+}
+
+.gif img {
+  max-width: 375px
+}
+
+p.warning {
+  background: #fff9df;
+  padding: 1rem;
+  font-size: .8rem;
+  line-height: 1.5;
+  color: #747160;
+  border-left: 2px solid #747160;
+}
+
+p.warning a {
+  color: #747160;
+  text-decoration: underline
+}
+
+.pagination {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin-top: 1.5rem;
+}
+
+@media screen and (min-width:600px) {
+  .pagination {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between
+  }
+}
+
+.pagination__item {
+  text-decoration: none;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.pagination__item:nth-child(2) {
+  margin-top: 1.5rem
+}
+
+@media screen and (min-width:600px) {
+  .pagination__item {
+    width: 275px;
+    padding: 15px;
+    border-radius: 4px
+  }
+
+  .pagination__item:first-of-type {
+    padding-right: 15px
+  }
+
+  .pagination__item:last-of-type {
+    margin-top: 0
+  }
+
+  .pagination__item:hover {
+    background-color: #f6f9fc
+  }
+}
+
+.pagination__label {
+  color: #9b9b9b;
+  font-size: .8rem
+}
+
+.pagination__title {
+  color: #111;
+  font-weight: 700;
+  margin-top: .25rem
+}
+
+footer {
+  text-align: center;
+  padding: 0 1.5rem;
+  background: #ffffff;
+}
+
+footer p {
+  color: #9b9b9b;
+  font-size: .65rem
+}
+
+.post__content ul {
+  list-style: none;
+}
+
+.post__content ul li {
+  margin-bottom: .5rem;
+}
+
+.post__content ul li::before {
+  content: '-';
+  color: #717171;
+  position: absolute;
+  margin-left: -15px
+}
+
+.twitter-tweet.twitter-tweet-rendered {
+  margin: 1.5rem auto !important;
+  width: 375px !important
+}
+
+.newsletter__buttondown-link {
+  display: none
+}

--- a/static/css/posts.css
+++ b/static/css/posts.css
@@ -1,1 +1,444 @@
-button,button[type="button"],button[type="reset"],button[type="submit"]{-webkit-appearance:button}input,input[type=text],input[type=email]{-webkit-appearance:none;-moz-appearance:none;appearance:none}html,body{background-color:#fff;color:#111;height:100%}html{-webkit-box-sizing:border-box;box-sizing:border-box}*,*:before,*:after{padding:0;margin:0;-webkit-box-sizing:inherit;box-sizing:inherit}html{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;-webkit-font-smoothing:antialiased;font-size:95%;}@media screen and (min-width:800px){html{font-size:100%}}@media screen and (min-width:1400px){html{font-size:115%}}h1,h2,h3,h4,h5,h6{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem;}h1{font-size:2.121rem;line-height:2.25rem;margin-top:2.25rem}h2{font-size:1.414rem}h3{font-size:1.414/2rem}h4{font-size:1.414/3rem}h5{font-size:1.414/4rem}p{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem}ul,ol{padding-left:1.5rem;margin-top:1.5rem;margin-bottom:1.5rem;}ul li,ol li{line-height:1.5rem}ul ul,ol ul,ul ol,ol ol{margin-top:0;margin-bottom:0}blockquote{margin-top:1.5rem;margin-bottom:1.5rem;line-height:1.5rem;color:#717171;font-style:italic}pre{line-height:1.45;margin-top:1.5rem;padding:16px;word-wrap:normal;overflow:auto;background-color:#f6f8fa;border-radius:3px}code{font-size:85%;font-family:"SFMono-Regular",Consolas,Menlo,monospace;padding:.2em .4em;margin:0;background-color:rgba(27,31,35,0.05);border-radius:3px}pre>code{word-break:normal;white-space:pre}pre code{display:inline;padding:0;margin:0;overflow:visible;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}.lead{font-size:1.414rem}.burger__container{height:4rem;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding:0 1.5rem;position:fixed;width:100%;background:#fff;z-index:2;}@media screen and (min-width:800px){.burger__container{display:none}}.burger{position:relative;width:28px;height:28px;cursor:pointer}.burger__meat{position:absolute;width:28px;height:2px;background:#111;top:calc(50% - 2px / 2);left:calc(50% - 28px / 2);-webkit-transition:all 150ms ease-in;transition:all 150ms ease-in}.burger__meat--1{-webkit-transform:translateY(-10px);transform:translateY(-10px)}.burger__meat--2{width:calc(28px - 6px)}.burger__meat--3{-webkit-transform:translateY(10px);transform:translateY(10px)}.nav--active .burger__meat--1{-webkit-transform:rotate(45deg);transform:rotate(45deg)}.nav--active .burger__meat--2{opacity:0}.nav--active .burger__meat--3{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.nav{font-size:16px;position:fixed;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background:#fff;visibility:hidden;z-index:1;}@media screen and (min-width:800px){.nav{display:block;visibility:visible;padding-top:3em;width:100px}}.nav--active .nav{visibility:visible;height:100%;width:100%}.nav__list{text-align:right;list-style:none;margin:0;padding:0;width:50%;}@media screen and (min-width:800px){.nav__list{width:auto}}@media screen and (max-width:799px){.nav__list{-webkit-transform:translateY(-25px);transform:translateY(-25px);opacity:0}.nav--active .nav__list{-webkit-transform:translateY(0);transform:translateY(0);opacity:1;-webkit-transition:all 500ms ease;transition:all 500ms ease}}.nav__list li{margin-bottom:3em;line-height:1.5em;}.nav__list li:last-of-type{margin-bottom:0}@media screen and (min-width:800px){.nav__list li{margin-bottom:1.75em}}.nav__list a{color:#9b9b9b;text-decoration:none;font-size:2em;}.nav__list a.active{color:#111}.nav__list a:hover{color:#111}@media screen and (min-width:800px){.nav__list a{font-size:1em}}body.nav--active{overflow:hidden}main{padding:3rem 1.5rem;}@media screen and (min-width:800px){main{padding-left:calc(1.5rem + 100px)}}@media screen and (max-width:799px){main{padding-top:calc(3rem + 4rem)}}.post-list__container{margin:0 auto;max-width:1200px;width:100%;}@media screen and (min-width:800px){.post-list__container{padding-left:50px}}.post-list{list-style:none;margin:0;padding:0}.post{margin-bottom:1.5rem}.post__title{margin-top:0;font-weight:500;}.post__title a{color:#111;text-decoration:none}.post__date{color:#9b9b9b;font-size:.8rem}.tags__list{list-style:none;padding:0;margin:0;padding-left:50px;-ms-flex-negative:0;flex-shrink:0;}@media screen and (max-width:799px){.tags__list{display:none}}.post__header .tags__list{display:none;padding-left:0;}@media screen and (max-width:799px){.post__header .tags__list{display:block}}.post__header .tags__list .tag__item{display:inline-block;margin-right:10px;}.post__header .tags__list .tag__item:last-child{margin-right:0}.post__header .tags__list .tag__link{font-size:.8rem}.tag__link{text-decoration:none;color:#9b9b9b;font-size:.9rem;}.tag__link::before{content:'#';font-size:.7rem;padding-right:1px}.tag__link:hover{color:#717171}.post-list__container{display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:justify;-ms-flex-pack:justify;justify-content:space-between}
+button,
+button[type="button"],
+button[type="reset"],
+button[type="submit"] {
+  -webkit-appearance: button
+}
+
+input,
+input[type=text],
+input[type=email] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+html,
+body {
+  background-color: #fff;
+  color: #111;
+  height: 100%
+}
+
+html {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+}
+
+*,
+*:before,
+*:after {
+  padding: 0;
+  margin: 0;
+  -webkit-box-sizing: inherit;
+  box-sizing: inherit
+}
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 95%;
+}
+
+@media screen and (min-width:800px) {
+  html {
+    font-size: 100%
+  }
+}
+
+@media screen and (min-width:1400px) {
+  html {
+    font-size: 115%
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem;
+}
+
+h1 {
+  font-size: 2.121rem;
+  line-height: 2.25rem;
+  margin-top: 2.25rem
+}
+
+h2 {
+  font-size: 1.414rem
+}
+
+h3 {
+  font-size: 1.414/2rem
+}
+
+h4 {
+  font-size: 1.414/3rem
+}
+
+h5 {
+  font-size: 1.414/4rem
+}
+
+p {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem
+}
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+ul li,
+ol li {
+  line-height: 1.5rem
+}
+
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0
+}
+
+blockquote {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
+  color: #717171;
+  font-style: italic;
+}
+
+pre {
+  line-height: 1.45;
+  margin-top: 1.5rem;
+  padding: 16px;
+  word-wrap: normal;
+  overflow: auto;
+  background-color: #f6f8fa;
+  border-radius: 3px
+}
+
+code {
+  font-size: 85%;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: rgba(27, 31, 35, 0.05);
+  border-radius: 3px
+}
+
+pre>code {
+  word-break: normal;
+  white-space: pre
+}
+
+pre code {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0
+}
+
+.lead {
+  font-size: 1.414rem
+}
+
+.burger__container {
+  height: 4rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0 1.5rem;
+  position: fixed;
+  width: 100%;
+  background: #fff;
+  z-index: 2;
+}
+
+@media screen and (min-width:800px) {
+  .burger__container {
+    display: none
+  }
+}
+
+.burger {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  cursor: pointer
+}
+
+.burger__meat {
+  position: absolute;
+  width: 28px;
+  height: 2px;
+  background: #111;
+  top: calc(50% - 2px / 2);
+  left: calc(50% - 28px / 2);
+  -webkit-transition: all 150ms ease-in;
+  transition: all 150ms ease-in
+}
+
+.burger__meat--1 {
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.burger__meat--2 {
+  width: calc(28px - 6px)
+}
+
+.burger__meat--3 {
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.nav--active .burger__meat--1 {
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg)
+}
+
+.nav--active .burger__meat--2 {
+  opacity: 0
+}
+
+.nav--active .burger__meat--3 {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg)
+}
+
+.nav {
+  font-size: 16px;
+  position: fixed;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fff;
+  visibility: hidden;
+  z-index: 1;
+}
+
+@media screen and (min-width:800px) {
+  .nav {
+    display: block;
+    visibility: visible;
+    padding-top: 3em;
+    width: 100px
+  }
+}
+
+.nav--active .nav {
+  visibility: visible;
+  height: 100%;
+  width: 100%
+}
+
+.nav__list {
+  text-align: right;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+@media screen and (min-width:800px) {
+  .nav__list {
+    width: auto
+  }
+}
+
+@media screen and (max-width:799px) {
+  .nav__list {
+    -webkit-transform: translateY(-25px);
+    transform: translateY(-25px);
+    opacity: 0
+  }
+
+  .nav--active .nav__list {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+    -webkit-transition: all 500ms ease;
+    transition: all 500ms ease
+  }
+}
+
+.nav__list li {
+  margin-bottom: 3em;
+  line-height: 1.5em;
+}
+
+.nav__list li:last-of-type {
+  margin-bottom: 0
+}
+
+@media screen and (min-width:800px) {
+  .nav__list li {
+    margin-bottom: 1.75em
+  }
+}
+
+.nav__list a {
+  color: #9b9b9b;
+  text-decoration: none;
+  font-size: 2em;
+}
+
+.nav__list a.active {
+  color: #111
+}
+
+.nav__list a:hover {
+  color: #111
+}
+
+@media screen and (min-width:800px) {
+  .nav__list a {
+    font-size: 1em
+  }
+}
+
+body.nav--active {
+  overflow: hidden
+}
+
+main {
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width:800px) {
+  main {
+    padding-left: calc(1.5rem + 100px)
+  }
+}
+
+@media screen and (max-width:799px) {
+  main {
+    padding-top: calc(3rem + 4rem)
+  }
+}
+
+.post-list__container {
+  margin: 0 auto;
+  max-width: 1200px;
+  width: 100%;
+}
+
+@media screen and (min-width:800px) {
+  .post-list__container {
+    padding-left: 50px
+  }
+}
+
+.post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0
+}
+
+.post {
+  margin-bottom: 1.5rem
+}
+
+.post__title {
+  margin-top: 0;
+  font-weight: 500;
+}
+
+.post__title a {
+  color: #111;
+  text-decoration: none
+}
+
+.post__date {
+  color: #9b9b9b;
+  font-size: .8rem
+}
+
+.tags__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  padding-left: 50px;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+@media screen and (max-width:799px) {
+  .tags__list {
+    display: none
+  }
+}
+
+.post__header .tags__list {
+  display: none;
+  padding-left: 0;
+}
+
+@media screen and (max-width:799px) {
+  .post__header .tags__list {
+    display: block
+  }
+}
+
+.post__header .tags__list .tag__item {
+  display: inline-block;
+  margin-right: 10px;
+}
+
+.post__header .tags__list .tag__item:last-child {
+  margin-right: 0
+}
+
+.post__header .tags__list .tag__link {
+  font-size: .8rem
+}
+
+.tag__link {
+  text-decoration: none;
+  color: #9b9b9b;
+  font-size: .9rem;
+}
+
+.tag__link::before {
+  content: '#';
+  font-size: .7rem;
+  padding-right: 1px
+}
+
+.tag__link:hover {
+  color: #717171
+}
+
+.post-list__container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between
+}

--- a/static/css/tags.css
+++ b/static/css/tags.css
@@ -1,1 +1,412 @@
-button,button[type="button"],button[type="reset"],button[type="submit"]{-webkit-appearance:button}input,input[type=text],input[type=email]{-webkit-appearance:none;-moz-appearance:none;appearance:none}html,body{background-color:#fff;color:#111;height:100%}html{-webkit-box-sizing:border-box;box-sizing:border-box}*,*:before,*:after{padding:0;margin:0;-webkit-box-sizing:inherit;box-sizing:inherit}html{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;-webkit-font-smoothing:antialiased;font-size:95%;}@media screen and (min-width:800px){html{font-size:100%}}@media screen and (min-width:1400px){html{font-size:115%}}h1,h2,h3,h4,h5,h6{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem;}h1{font-size:2.121rem;line-height:2.25rem;margin-top:2.25rem}h2{font-size:1.414rem}h3{font-size:1.414/2rem}h4{font-size:1.414/3rem}h5{font-size:1.414/4rem}p{margin-top:1.5rem;margin-bottom:0;line-height:1.5rem}ul,ol{padding-left:1.5rem;margin-top:1.5rem;margin-bottom:1.5rem;}ul li,ol li{line-height:1.5rem}ul ul,ol ul,ul ol,ol ol{margin-top:0;margin-bottom:0}blockquote{margin-top:1.5rem;margin-bottom:1.5rem;line-height:1.5rem;color:#717171;font-style:italic}pre{line-height:1.45;margin-top:1.5rem;padding:16px;word-wrap:normal;overflow:auto;background-color:#f6f8fa;border-radius:3px}code{font-size:85%;font-family:"SFMono-Regular",Consolas,Menlo,monospace;padding:.2em .4em;margin:0;background-color:rgba(27,31,35,0.05);border-radius:3px}pre>code{word-break:normal;white-space:pre}pre code{display:inline;padding:0;margin:0;overflow:visible;line-height:inherit;word-wrap:normal;background-color:transparent;border:0}.lead{font-size:1.414rem}.burger__container{height:4rem;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:center;-ms-flex-align:center;align-items:center;padding:0 1.5rem;position:fixed;width:100%;background:#fff;z-index:2;}@media screen and (min-width:800px){.burger__container{display:none}}.burger{position:relative;width:28px;height:28px;cursor:pointer}.burger__meat{position:absolute;width:28px;height:2px;background:#111;top:calc(50% - 2px / 2);left:calc(50% - 28px / 2);-webkit-transition:all 150ms ease-in;transition:all 150ms ease-in}.burger__meat--1{-webkit-transform:translateY(-10px);transform:translateY(-10px)}.burger__meat--2{width:calc(28px - 6px)}.burger__meat--3{-webkit-transform:translateY(10px);transform:translateY(10px)}.nav--active .burger__meat--1{-webkit-transform:rotate(45deg);transform:rotate(45deg)}.nav--active .burger__meat--2{opacity:0}.nav--active .burger__meat--3{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.nav{font-size:16px;position:fixed;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background:#fff;visibility:hidden;z-index:1;}@media screen and (min-width:800px){.nav{display:block;visibility:visible;padding-top:3em;width:100px}}.nav--active .nav{visibility:visible;height:100%;width:100%}.nav__list{text-align:right;list-style:none;margin:0;padding:0;width:50%;}@media screen and (min-width:800px){.nav__list{width:auto}}@media screen and (max-width:799px){.nav__list{-webkit-transform:translateY(-25px);transform:translateY(-25px);opacity:0}.nav--active .nav__list{-webkit-transform:translateY(0);transform:translateY(0);opacity:1;-webkit-transition:all 500ms ease;transition:all 500ms ease}}.nav__list li{margin-bottom:3em;line-height:1.5em;}.nav__list li:last-of-type{margin-bottom:0}@media screen and (min-width:800px){.nav__list li{margin-bottom:1.75em}}.nav__list a{color:#9b9b9b;text-decoration:none;font-size:2em;}.nav__list a.active{color:#111}.nav__list a:hover{color:#111}@media screen and (min-width:800px){.nav__list a{font-size:1em}}body.nav--active{overflow:hidden}main{padding:3rem 1.5rem;}@media screen and (min-width:800px){main{padding-left:calc(1.5rem + 100px)}}@media screen and (max-width:799px){main{padding-top:calc(3rem + 4rem)}}.post-list__container{margin:0 auto;max-width:1200px;width:100%;}@media screen and (min-width:800px){.post-list__container{padding-left:50px}}.post-list{list-style:none;margin:0;padding:0}.post{margin-bottom:1.5rem}.post__title{margin-top:0;font-weight:500;}.post__title a{color:#111;text-decoration:none}.post__date{color:#9b9b9b;font-size:.8rem}.tag__header{-webkit-box-align:baseline;-ms-flex-align:baseline;align-items:baseline;display:-webkit-box;display:-ms-flexbox;display:flex;margin:0 auto;margin-bottom:3rem;}.tag__header a,.tag__header .separator{color:#9b9b9b;font-size:1.5rem}.tag__header a{text-decoration:none}.tag__header .separator{-ms-flex-item-align:center;align-self:center;margin:0 5px}.tag__header .tag__term{margin:0;font-weight:600}
+button,
+button[type="button"],
+button[type="reset"],
+button[type="submit"] {
+  -webkit-appearance: button
+}
+
+input,
+input[type=text],
+input[type=email] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none
+}
+
+html,
+body {
+  background-color: #fff;
+  color: #111;
+  height: 100%
+}
+
+html {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+}
+
+*,
+*:before,
+*:after {
+  padding: 0;
+  margin: 0;
+  -webkit-box-sizing: inherit;
+  box-sizing: inherit
+}
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 95%;
+}
+
+@media screen and (min-width:800px) {
+  html {
+    font-size: 100%
+  }
+}
+
+@media screen and (min-width:1400px) {
+  html {
+    font-size: 115%
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem;
+}
+
+h1 {
+  font-size: 2.121rem;
+  line-height: 2.25rem;
+  margin-top: 2.25rem
+}
+
+h2 {
+  font-size: 1.414rem
+}
+
+h3 {
+  font-size: 1.414/2rem
+}
+
+h4 {
+  font-size: 1.414/3rem
+}
+
+h5 {
+  font-size: 1.414/4rem
+}
+
+p {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  line-height: 1.5rem
+}
+
+ul,
+ol {
+  padding-left: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+ul li,
+ol li {
+  line-height: 1.5rem
+}
+
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0
+}
+
+blockquote {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
+  color: #717171;
+  font-style: italic;
+}
+
+pre {
+  line-height: 1.45;
+  margin-top: 1.5rem;
+  padding: 16px;
+  word-wrap: normal;
+  overflow: auto;
+  background-color: #f6f8fa;
+  border-radius: 3px
+}
+
+code {
+  font-size: 85%;
+  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  padding: .2em .4em;
+  margin: 0;
+  background-color: rgba(27, 31, 35, 0.05);
+  border-radius: 3px
+}
+
+pre>code {
+  word-break: normal;
+  white-space: pre
+}
+
+pre code {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0
+}
+
+.lead {
+  font-size: 1.414rem
+}
+
+.burger__container {
+  height: 4rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0 1.5rem;
+  position: fixed;
+  width: 100%;
+  background: #fff;
+  z-index: 2;
+}
+
+@media screen and (min-width:800px) {
+  .burger__container {
+    display: none
+  }
+}
+
+.burger {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  cursor: pointer
+}
+
+.burger__meat {
+  position: absolute;
+  width: 28px;
+  height: 2px;
+  background: #111;
+  top: calc(50% - 2px / 2);
+  left: calc(50% - 28px / 2);
+  -webkit-transition: all 150ms ease-in;
+  transition: all 150ms ease-in
+}
+
+.burger__meat--1 {
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.burger__meat--2 {
+  width: calc(28px - 6px)
+}
+
+.burger__meat--3 {
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.nav--active .burger__meat--1 {
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg)
+}
+
+.nav--active .burger__meat--2 {
+  opacity: 0
+}
+
+.nav--active .burger__meat--3 {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg)
+}
+
+.nav {
+  font-size: 16px;
+  position: fixed;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #fff;
+  visibility: hidden;
+  z-index: 1;
+}
+
+@media screen and (min-width:800px) {
+  .nav {
+    display: block;
+    visibility: visible;
+    padding-top: 3em;
+    width: 100px
+  }
+}
+
+.nav--active .nav {
+  visibility: visible;
+  height: 100%;
+  width: 100%
+}
+
+.nav__list {
+  text-align: right;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+@media screen and (min-width:800px) {
+  .nav__list {
+    width: auto
+  }
+}
+
+@media screen and (max-width:799px) {
+  .nav__list {
+    -webkit-transform: translateY(-25px);
+    transform: translateY(-25px);
+    opacity: 0
+  }
+
+  .nav--active .nav__list {
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+    opacity: 1;
+    -webkit-transition: all 500ms ease;
+    transition: all 500ms ease
+  }
+}
+
+.nav__list li {
+  margin-bottom: 3em;
+  line-height: 1.5em;
+}
+
+.nav__list li:last-of-type {
+  margin-bottom: 0
+}
+
+@media screen and (min-width:800px) {
+  .nav__list li {
+    margin-bottom: 1.75em
+  }
+}
+
+.nav__list a {
+  color: #9b9b9b;
+  text-decoration: none;
+  font-size: 2em;
+}
+
+.nav__list a.active {
+  color: #111
+}
+
+.nav__list a:hover {
+  color: #111
+}
+
+@media screen and (min-width:800px) {
+  .nav__list a {
+    font-size: 1em
+  }
+}
+
+body.nav--active {
+  overflow: hidden
+}
+
+main {
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width:800px) {
+  main {
+    padding-left: calc(1.5rem + 100px)
+  }
+}
+
+@media screen and (max-width:799px) {
+  main {
+    padding-top: calc(3rem + 4rem)
+  }
+}
+
+.post-list__container {
+  margin: 0 auto;
+  max-width: 1200px;
+  width: 100%;
+}
+
+@media screen and (min-width:800px) {
+  .post-list__container {
+    padding-left: 50px
+  }
+}
+
+.post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0
+}
+
+.post {
+  margin-bottom: 1.5rem
+}
+
+.post__title {
+  margin-top: 0;
+  font-weight: 500;
+}
+
+.post__title a {
+  color: #111;
+  text-decoration: none
+}
+
+.post__date {
+  color: #9b9b9b;
+  font-size: .8rem
+}
+
+.tag__header {
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0 auto;
+  margin-bottom: 3rem;
+}
+
+.tag__header a,
+.tag__header .separator {
+  color: #9b9b9b;
+  font-size: 1.5rem
+}
+
+.tag__header a {
+  text-decoration: none
+}
+
+.tag__header .separator {
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin: 0 5px
+}
+
+.tag__header .tag__term {
+  margin: 0;
+  font-weight: 600
+}


### PR DESCRIPTION
The following changes are made to enhance the current theme:

- Adding additional sample posts from Hugo md templates, including rich content, markdown syntax and math typesetting to test the current theme
- Add `math.html` and add that partial to `single.html` so users can enable katex in posts
- Update `post.styl` and `post.css` for footer (currently showing different colour of footer to the background, i.e. #ffffff)
- Beautify format of css files

Additional suggestions:
- Syntax highlight doesn't seem to work well (but I'm not sure how to change it)
![image](https://user-images.githubusercontent.com/30974572/83877559-121f9900-a77e-11ea-9fd3-543251bcf498.png)
- ExampleSite doesn't seem to reflect all the changes I made, e.g. katex works well in the main content but not the example site (which i assume is less of an issue?)
- There doesn't seem to have a good way of creating additional custom pages other than blog and about?

@jakewies 
Overall it's been so great having this theme to the community. Thanks so much 👏👏👏