### PR TITLE
update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ First off, thank you for your time and effort! This project is not very large an
 - Built with [Hugo](https://gohugo.io/) 🔥
 - [Gulp](https://gulpjs.com/) as a build tool 🍹
 - Styles in [Stylus](http://stylus-lang.com/) 💅🏻
+- [Yarn](https://yarnpkg.com/) as a package manager 📦
 
 ## Getting started
 


### PR DESCRIPTION
Added some missing information.

A couple of questions: 

If the README instructs the user to clone the package as "codex", shouldn't that be the default name for it in exampleSite/config.toml?

Why hide really simple one-liners behind yarn scripts? It would be more transparent and instructive to just show how to run the original commands.