### PR TITLE
Use RelPermalink instead of Permalink

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
   
   {{ range (slice $base_styles_opts $custom_styles_opts) }}
     {{ $style := resources.Get .src | resources.ExecuteAsTemplate .dest $current_page | toCSS | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}"/>
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}"/>
   {{ end }}
   
   {{ range .AlternativeOutputFormats }} 
@@ -58,7 +58,7 @@
   {{ block "footer" . }} {{ end }}
 
   {{ $script := resources.Get "js/index.js" | minify | fingerprint }}
-  <script src="{{ $script.Permalink }}" integrity="{{ $script.Data.Integrity | safeHTMLAttr }}" crossorigin="anonymous"></script>
+  <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity | safeHTMLAttr }}" crossorigin="anonymous"></script>
   {{ block "scripts" . }} {{ end }}
 </body>
 


### PR DESCRIPTION
I just realized that the generated static resources were using `.Permalink`, which appended the site's `baseUrl` in front. This would break Netlify previews as they use a different temporary baseUrl. 

The simple fix is to change to `.RelPermalink`, which churns out `/css/<name>.css` instead of `<baseUrl>/css/<name>.css`. Tested with my Netlify pipeline.