### PR TITLE
Fix site's title to be more SEO friendly

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
 
-  <title>{{ .Page.Title }}</title>
+  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
   <meta charset="UTF-8">
   <meta name="language" content="en">


### PR DESCRIPTION
We're currently using `{{ .Page.Title }}` for the website's title. The problem is this value will be empty for the home page.

Following [this article](https://harrycresswell.com/articles/hugo-seo-accurate-page-titles/), we can update the title to use a combination of `.Site.Title` and `.Title` (same as `.Page.Title`) in order to make it unique for every page.