### PR TITLE
Make dateFormat configurable

### DIFF
--- a/assets/scss/partials/_post-list.scss
+++ b/assets/scss/partials/_post-list.scss
@@ -1,3 +1,6 @@
+@import "colors";
+@import "vars";
+
 .post-list__container {
   margin: 0 auto;
   max-width: 1200px;

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,8 @@ themesDir = "../../"
 
 # Optional params
 [params]
+  dateFormat = "Jan 2 2006"
+
   # Links to your social accounts, comment/uncomment as needed. Icons will be displayed for those specified.
   twitter = "https://twitter.com/<your handle>"
   github = "https://github.com/<your handle>"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -15,6 +15,8 @@ themesDir = "../../"
 
 # Optional params
 [params]
+  # Follow the Hugo date/time format reference here: 
+  # https://gohugo.io/functions/format/#gos-layout-string
   dateFormat = "Jan 2 2006"
 
   # Links to your social accounts, comment/uncomment as needed. Icons will be displayed for those specified.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,6 +3,8 @@
 {{ end }}
 
 {{ define "main" }}
+    
+{{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}    
 
 <div class="post-list__container">
   <ul class="post-list">
@@ -10,8 +12,7 @@
     <li class="post">
       <div class="post__header">
         <time class="post__date" datetime="{{ .Date }}"
-          >{{ .Date.Format "Jan 2 2006" }}</time
-        >
+          >{{ .Date.Format $dateFormat }}</time>
         <h2 class="post__title">
           <a href="{{.RelPermalink}}">{{ .Title }}</a>
         </h2>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,11 +3,13 @@
 {{ end }}
 
 {{ define "main" }}
+{{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
+
 <div class="post">
   <header class="post__header">
     <h1 class="post__title">{{.Title}}</h1>
     <time datetime="{{ .Date }}" class="post__date"
-      >{{ .Date.Format "Jan 2 2006" }}</time
+      >{{ .Date.Format $dateFormat }}</time
     >
   </header>
   <article class="post__content">

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -3,6 +3,8 @@
 {{ end }}
 
 {{ define "main" }} 
+  {{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}        
+    
   <div class="post-list__container">
     <div class="tag__header">
       <a href="/blog">All posts</a><span class="separator">/</span>
@@ -12,7 +14,7 @@
       {{ range .Data.Pages }}
       <li class="post">
         <div class="post__header">
-          <time class="post__date" datetime="{{ .Date }}">{{ .Date.Format "Jan 2 2006" }}</time>
+          <time class="post__date" datetime="{{ .Date }}">{{ .Date.Format $dateFormat }}</time>
           <h2 class="post__title">
             <a href="{{.RelPermalink}}">{{ .Title }}</a>
           </h2>


### PR DESCRIPTION
The dateFormat is currently a magic string in several templates. I think it's better to extract it as an user configurable parameter.

Also adding `@import` statements for `_post-list.scss`, not that necessary but it'll stop IDEs from complaining.