### PR TITLE
Enable raw HTML by default

### DIFF
--- a/assets/scss/pages/post.scss
+++ b/assets/scss/pages/post.scss
@@ -1,5 +1,6 @@
 @import '../main';
 @import '../partials/github-syntax-highlighting';
+@import '../partials/colors';
 
 .post {
   width: 100%;
@@ -235,4 +236,19 @@ footer {
 .twitter-tweet.twitter-tweet-rendered {
   margin: 1.5rem auto !important;
   width: 375px !important;
+}
+
+table {
+  max-width: 100%;
+  border-spacing: 0;
+
+  thead {
+    background: $lightGrey;
+  }
+
+  th,
+  td {
+    padding: 0.5em 1em;
+    border: 1px double $greyTableBorder;
+  }
 }

--- a/assets/scss/partials/_colors.scss
+++ b/assets/scss/partials/_colors.scss
@@ -1,4 +1,6 @@
 $black: #111;
+$lightGrey: #F7F7F7;
+$greyTableBorder: #EEEEEE;
 $grey: #9B9B9B;
 $darkGrey: #717171;
 $white: #fff;

--- a/assets/scss/partials/_typography.scss
+++ b/assets/scss/partials/_typography.scss
@@ -72,11 +72,34 @@ ol {
 }
 
 blockquote {
+  &::before {
+    position: absolute;
+    content: '\201C';
+
+    font-size: 6em;
+    font-family: 'Roboto', serif;
+    margin-top: 0.10em;;
+    margin-left: -0.2em;
+    
+    z-index: -1;
+    color: darken($white, 7%);
+  }
+  
   margin-top: $leading;
   margin-bottom: $leading;
   line-height: $leading;
-  color: $darkGrey;
-  font-style: italic;
+  color: $black;
+  
+  cite {
+    &::before {
+      content: "— "
+    }
+    
+    font-style: italic;
+    font-size: .95em;
+    color: $darkGrey;
+  }
+
 }
 
 pre {

--- a/assets/scss/partials/_typography.scss
+++ b/assets/scss/partials/_typography.scss
@@ -117,3 +117,7 @@ pre code {
 .lead {
   font-size: $scale * 1rem;
 }
+
+abbr[title] {
+  text-decoration: underline double;
+}

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -41,6 +41,10 @@ themesDir = "../../"
 [markup]
   [markup.highlight]
     codeFences = false
+    
+  # Set to false to disallow raw HTML in markdown files
+  [markup.goldmark.renderer]
+      unsafe = true
 
 # Controls the navigation
 [[menu.main]]

--- a/exampleSite/content/blog/markdown-syntax.md
+++ b/exampleSite/content/blog/markdown-syntax.md
@@ -38,6 +38,14 @@ The blockquote element represents content that is quoted from another source, op
 > Tiam, ad mint andaepu dandae nostion secatur sequo quae.
 > **Note** that you can use *Markdown syntax* within a blockquote.
 
+#### Blockquote with attribution
+
+> Simplicity is the ultimate sophistication.
+> — <cite>Leonardo da Vinci[^1]</cite>
+
+[^1]: The above quote is often attributed to Leonardo da Vinci but there is no concrete evidence to support this.
+
+
 ## Tables
 
 Tables aren't part of the core Markdown spec, but Hugo supports supports them out-of-the-box.

--- a/exampleSite/content/blog/markdown-syntax.md
+++ b/exampleSite/content/blog/markdown-syntax.md
@@ -41,7 +41,7 @@ The blockquote element represents content that is quoted from another source, op
 #### Blockquote with attribution
 
 > Simplicity is the ultimate sophistication.
-> — <cite>Leonardo da Vinci[^1]</cite>
+> <cite>Leonardo da Vinci[^1]</cite>
 
 [^1]: The above quote is often attributed to Leonardo da Vinci but there is no concrete evidence to support this.
 


### PR DESCRIPTION
- I noticed that several examples in the `Markdown Syntax Guide` page are broken. 

  ![image](https://user-images.githubusercontent.com/7024160/85425429-c194a200-b5ab-11ea-8ca2-0e1aba66dffa.png)

  It turns out that starting from Hugu 0.60, [raw HTML are disabled by default](https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032/2). We can simply enable that in the example config.

  After:

  ![image](https://user-images.githubusercontent.com/7024160/85425508-d96c2600-b5ab-11ea-9e9d-bd076185bb1b.png)

- Also I added some basic stylings to tables & blockquotes, feel free to help me make them look better 😆 

  Before:
  ![image](https://user-images.githubusercontent.com/7024160/85428677-2651fb80-b5b0-11ea-9e3f-16fa3924a18d.png)

  After:
  ![image](https://user-images.githubusercontent.com/7024160/85428711-35d14480-b5b0-11ea-8469-b7c201fd7577.png)

  


