### PR TITLE
Add support for Disqus and Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A minimal blog theme built for [Hugo](https://gohugo.io/) 🍜
 - Blog posts can be tagged 🏷
 - Mathematical notations are supported with KaTex 📐
 - Sass/SCSS for styling ✨
+- Support for Google Analytics 📈 and Disqus 💬
 
 ### Prerequisites
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,12 @@ theme = "hugo-theme-codex"
 # This is only to get the exampleSite to work in this repo.
 themesDir = "../../" 
 
+# Add your Disqus shortname here.
+# disqusShortname = ""
+
+# Add your Google Analytics identifier: UA-XXXXXXXX-X
+# googleAnalytics = "" 
+
 # Optional params
 [params]
   # Follow the Hugo date/time format reference here: 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,8 +2,6 @@
 <html lang="{{ .Site.LanguageCode }}">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
   <meta charset="UTF-8">
@@ -13,7 +11,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="google-site-verification" content="8cyiY374WL2LGr87fBghcdJCRx6BaPNBvLjeZlk6tyc" />
 
   <!-- Twitter -->
   {{ if isset .Site.Params "twitter" }}
@@ -44,6 +41,10 @@
   {{ end }} 
   {{ block "links" . }} {{ end }}
   {{ partial "seo-schema.html" .}}
+
+  {{- if not .Site.IsServer -}}
+      {{ template "_internal/google_analytics_async.html" . }}
+  {{- end -}}
 </head>
 
 <body>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,28 +3,34 @@
 {{ end }}
 
 {{ define "main" }}
-{{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
+    {{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
 
-<div class="post">
-  <header class="post__header">
-    <h1 class="post__title">{{.Title}}</h1>
-    <time datetime="{{ .Date }}" class="post__date"
-      >{{ .Date.Format $dateFormat }}</time
-    >
-  </header>
-  <article class="post__content">
-    {{ partial "anchored-headings.html" .Content }}
-    {{ if or .Params.math .Site.Params.math }}
-      {{ partial "math.html" . }}
-    {{ end }}
-  </article>
-  {{ partial "tags.html" .}} {{ partial "post-pagination.html" .}}
-</div>
-{{ end }} {{ define "footer" }}
-<footer>
-  {{ partial "social-icons.html" .}}
-  <p>{{ replace .Site.Copyright "{year}" now.Year }}</p>
-</footer>
-{{ end }} {{ define "scripts" }}
-<script src="https://unpkg.com/prismjs@^1.2"></script>
+    <div class="post">
+      <header class="post__header">
+        <h1 class="post__title">{{.Title}}</h1>
+        <time datetime="{{ .Date }}" class="post__date"
+        >{{ .Date.Format $dateFormat }}</time>
+      </header>
+      <article class="post__content">
+          {{ partial "anchored-headings.html" .Content }}
+          {{ if or .Params.math .Site.Params.math }}
+              {{ partial "math.html" . }}
+          {{ end }}
+      </article>
+        {{ partial "tags.html" .}} {{ partial "post-pagination.html" .}}
+    </div>
+
+    {{ template "_internal/disqus.html" . }}
+    
+{{ end }} 
+
+{{ define "footer" }}
+  <footer>
+      {{ partial "social-icons.html" .}}
+    <p>{{ replace .Site.Copyright "{year}" now.Year }}</p>
+  </footer>
+{{ end }} 
+
+{{ define "scripts" }}
+  <script src="https://unpkg.com/prismjs@^1.2"></script>
 {{ end }}


### PR DESCRIPTION
We can easily integrate Disqus and Google Analytics by utilizing Hugo's existing [internal templates](https://gohugo.io/templates/internal/). Users can opt in by specifying configs.

![image](https://user-images.githubusercontent.com/7024160/85516801-31993b80-b631-11ea-895f-f19c8c42d71b.png)

Also I reformatted `layouts/_default/single.html` since it was a little bit messy.