### PR TITLE
Change how prismjs is loaded.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -32,5 +32,8 @@
 {{ end }} 
 
 {{ define "scripts" }}
-  <script src="https://unpkg.com/prismjs@^1.2"></script>
+  {{/* Hardcode a specific prismjs version to avoid a redirect on every page load. */}}
+  <script src="https://unpkg.com/prismjs@1.20.0/components/prism-core.min.js"></script>
+  <script src="https://unpkg.com/prismjs@1.20.0/plugins/autoloader/prism-autoloader.min.js"
+    data-autoloader-path="https://unpkg.com/prismjs@1.20.0/components/"></script>
 {{ end }}


### PR DESCRIPTION
 - Load minified code (3kB vs 30kB)
 - Add prism autoloader so that we get highlighting for languages we
   use.
 - Hardcode exact prism version.  Perhaps this is controversial, but it
   saves a redirect for each request, shaving off 30ms on a fast
   connection.