### PR TITLE
Fix section anchors.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,6 +12,17 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
+  {{/* Elsewhere we use unpkg as a CDN, but it doesn't have a minified version of anchorjs. */}}
+  <script defer src="https://cdn.jsdelivr.net/npm/anchor-js@4.2.2/anchor.min.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function(event) {
+    anchors.options.visible = 'always';
+    anchors.options.placement = 'left';
+    anchors.add(".post__content h2, .post__content h3, .post__content h4, " +
+                ".post__content h5, .post__content h6");
+  });
+  </script>
+
   <!-- Twitter -->
   {{ if isset .Site.Params "twitter" }}
   <meta name="twitter:card" content="summary" />

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,7 +12,7 @@
         >{{ .Date.Format $dateFormat }}</time>
       </header>
       <article class="post__content">
-          {{ partial "anchored-headings.html" .Content }}
+          {{ .Content }}
           {{ if or .Params.math .Site.Params.math }}
               {{ partial "math.html" . }}
           {{ end }}

--- a/layouts/partials/anchored-headings.html
+++ b/layouts/partials/anchored-headings.html
@@ -1,2 +1,0 @@
-<!-- formats .Content headings by adding an anchor -->
-{{ . | replaceRE "(<h[2-3] id=\"([^\"]+)\".+)(</h[2-9]+>)" "${1}<a class=\"anchor\" href=\"#${2}\">#</a>${3}" | safeHTML }}


### PR DESCRIPTION
Previously if you navigated to a section anchor, it would take you to
right *below* the section heading.  This isn't what you want; you want
to know that you actually got to the proper section.

It's possible to solve this with the approach taken in
anchored-headings.html, but

  * we are parsing HTML using regular expressions: https://stackoverflow.com/a/1732454/61394
  * using JS for this seems to be the canonical way to do it in Hugo,
    see e.g. https://github.com/gohugoio/hugoDocs/blob/0373e4310263ac9f2b0307d437dcf69cf474eb69/themes/gohugoioTheme/src/js/anchorforid.js

Instead, simply use anchorjs.

Note that this changes the anchor icon from `#` to `🔗`.  I can change
it back to `#` if desired, or we can make it configurable.

Doing what could be server-side rendering on the client makes me feel a
little icky, but it's not much different than how we handle mathjax or
syntax highlighting.