### PR TITLE
Fix #58: excessing bottom padding

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -10,7 +10,7 @@ body.nav--active {
 }
 
 main {
-  padding: 3rem 1.5rem;
+  padding: 3rem 1.5rem 1rem;
 
 
   @media screen and (min-width: $medium) {


### PR DESCRIPTION
After #10, `<footer>` is nested inside `<main>` so now there is a 3rem padding at the bottom of every page. This PR changes it to 1rem which is more reasonable (Fixing #58).

Before:
![image](https://user-images.githubusercontent.com/7024160/85931641-70ace280-b8f8-11ea-8a04-018328f267eb.png)

After:
![image](https://user-images.githubusercontent.com/7024160/85931647-7f939500-b8f8-11ea-8d70-62d077945112.png)
