### PR TITLE
docs: Clean up README and config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ choco install hugo-extended -confirm
 At the root of your Hugo project, run:
 
 ```bash
-git submodule add https://github.com/jakewies/hugo-theme-codex.git themes/codex
+git submodule add https://github.com/jakewies/hugo-theme-codex.git themes/hugo-theme-codex
 ```
 
-Next, copy the contents of the [default `config.toml`](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml) to your site's `config.toml`. Make sure to read all the comments, as there a few nuances with Hugo themes that require some changes to that file. 
+Next, copy the contents of the [`exampleSite/config.toml`](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml) to your site's `config.toml`. Make sure to read all the comments, as there a few nuances with Hugo themes that require some changes to that file.
+
+The most important change you will need to make to the `config.toml` is removing [this line](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml#L14):
+
+```
+themesDir = "../../" 
+```
+
+It only exists in the example site so that the demo can function properly.
 
 Finally, run:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git submodule add https://github.com/jakewies/hugo-theme-codex.git themes/hugo-t
 
 Next, copy the contents of the [`exampleSite/config.toml`](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml) to your site's `config.toml`. Make sure to read all the comments, as there a few nuances with Hugo themes that require some changes to that file.
 
-The most important change you will need to make to the `config.toml` is removing [this line](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml#L14):
+The most important change you will need to make to the `config.toml` is removing [this line](https://github.com/jakewies/hugo-theme-codex/blob/master/exampleSite/config.toml#L2):
 
 ```
 themesDir = "../../" 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,17 +1,13 @@
+# REMOVE THIS
+themesDir = "../../" 
+
+# DO NOT REMOVE THIS
+theme = "hugo-theme-codex" 
+
 # Override these settings with your own
 languageCode = "en-us"
 baseURL = "https://example.org/"
 copyright = "© {year}"
-
-# The value "hugo-theme-codex" is only to get the exampleSite
-# to work in this repo. Change to whatever name you gave the theme
-# when you added it. If you followed the README, you should have 
-# added the theme using the name "codex".
-theme = "hugo-theme-codex" 
-
-# REMOVE THIS!
-# This is only to get the exampleSite to work in this repo.
-themesDir = "../../" 
 
 # Add your Disqus shortname here.
 # disqusShortname = ""


### PR DESCRIPTION
I noticed a few gotchas that might trip up newcomers to the project, so I tried to make things as clear as possible:

- Changed the name of the theme in the installation instruction from `themes/codex` to `themes/hugo-theme-codex` to stay consistent
- Be explicit as to where the `exampleSite/config.toml` file is located
- The 1 mandatory line that needs to be addressed in `exampleSite/config.toml` has been moved to the very top