### PR TITLE
Fix relative icon issue + add title

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,7 @@ themesDir = "../../"
 theme = "hugo-theme-codex" 
 
 # Override these settings with your own
+title = "codex"
 languageCode = "en-us"
 baseURL = "https://example.org/"
 copyright = "© {year}"

--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -6,7 +6,7 @@
     {{ $icon := anchorize . }} 
     {{ if isset $currentPage.Site.Params $icon }}
       <a class="social-icons__icon" title="{{ . }}"
-         style="background-image: url(/images/social/{{ $icon }}.svg)" 
+         style="background-image: url('{{print "images/social/" $icon ".svg" | absURL}}')" 
          href="{{ index $currentPage.Site.Params $icon }}"
          target="_blank" rel="noopener">
       </a>


### PR DESCRIPTION
This fixes the bug where the social icons don't appear on the demo page.
Now icons will use absolute URLs:
![image](https://user-images.githubusercontent.com/7024160/86518328-9d667a00-be63-11ea-9037-73ded5dffa18.png)

Also, I added a title to the exampleSite's config so that page titles will appear as `<page> | codex` instead of `<page> |`:
![image](https://user-images.githubusercontent.com/7024160/86518312-63957380-be63-11ea-9119-b202b814e198.png)


