### PR TITLE
Fix nav display error when expanding window with open burger.

### DIFF
--- a/assets/scss/partials/_nav.scss
+++ b/assets/scss/partials/_nav.scss
@@ -22,6 +22,10 @@
   visibility: visible;
   height: 100%;
   width: 100%;
+
+  @media screen and (min-width: $medium) {
+    width: $navWidth;
+  }
 }
 
 .nav__list {


### PR DESCRIPTION
Fix an issue where if the burger menu is expanded and then the browser window is expanded, the standard navigation is pushed to far right of the window. The navigation items stay there until the browser window is shrunk down once again to show the burger menu. 

![image](https://user-images.githubusercontent.com/6208288/86872953-b9f8f100-c0b3-11ea-8482-30c718b9bc01.png)
