### PR TITLE
#73 Enable summary for the post in blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Thumbs.db
 
 # Hugo
 public/
+
+# Web Storm
+/.idea/

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,6 +61,3 @@ copyright = "© {year}"
   name = "blog"
   title = "Blog"
   url = "/blog"
-
-
-

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,12 +3,12 @@
 {{ end }}
 
 {{ define "main" }}
-    
-{{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}    
+
+{{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
 
 <div class="post-list__container">
   <ul class="post-list">
-    {{ range .Pages }}
+    {{ range  (.Paginator 5).Pages }}
     <li class="post">
       <div class="post__header">
         <time class="post__date" datetime="{{ .Date }}"
@@ -16,6 +16,13 @@
         <h2 class="post__title">
           <a href="{{.RelPermalink}}">{{ .Title }}</a>
         </h2>
+          {{ .Summary }}
+          {{ if .Truncated }}
+          <!-- This <div> includes a read more link, but only if the summary is truncated... -->
+          <div class="post__title" align="right">
+              <a href="{{ .RelPermalink }}">Read More</a>
+          </div>
+          {{ end }}
         {{ partial "tags.html" .}}
       </div>
     </li>
@@ -23,5 +30,7 @@
   </ul>
   {{ partial "browse-by-tag.html" .}}
 </div>
+
+{{ partial "pagination.html" . }}
 
 {{ end }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,7 +1,14 @@
-<div class="paginator-container">
-  {{ if .Paginator.HasPrev }}
-  <a class="paginator paginator--left" href="{{ .Paginator.Prev.URL }}"></a>
-  {{ end }} {{ if .Paginator.HasNext }}
-  <a class="paginator paginator--right" href="{{ .Paginator.Next.URL }}"></a>
-  {{ end }}
-</div>
+{{ if gt .Paginator.TotalPages 1}}
+<!-- Pagination -->
+<nav class="post__title" style="text-align: center; line-height: 2.3em; ">
+    {{ $paginator := .Paginator }}
+    {{ range .Paginator.Pagers }}
+    {{ if eq .PageNumber $paginator.PageNumber }}
+    <span class="pagination__page pagination__page--current" style="background-color: #d73a49; padding: 8px 15px; color: #ffffff; font-weight: bold;">{{ .PageNumber }}</span>
+    {{ else }}
+    <a href="{{ .URL }}" class="pagination__page" style="padding: 8px 15px;">{{ .PageNumber }}</a>
+    {{ end }}
+    {{ end }}
+</nav>
+{{ end }}
+


### PR DESCRIPTION
The changes add a clean navigation bar in the bottom of the blog.
![image](https://user-images.githubusercontent.com/4903148/87338221-70e8e700-c562-11ea-8185-c670cbe2771a.png)

The active element will be bold and highlighted