### PR TITLE
Include a build:example script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,13 @@ Runs prettier on the entire project directory.
 ## Assets
 
 The `assets/` directory is where you can write JS and SCSS, which get processed
-into CSS files before being placed in the `static/` directory.
+into CSS files before being placed in the `static/` directory. 
+
+### Making `scss` changes
+
+If you make a change to a source `scss` file in `assets/scss`, you will need to make sure that you rebuild the `exampleSite/resources/_gen/assets/` directory to reflect the change in the demo site, else the demo's styles will become stale.
+
+If you are running `yarn develop`, `hugo` will pick up these changes by default. You can also run `yarn build:example`, which will trigger a one-time rebuild of the example site. From there, commit the updated `resources/_gen` directory to version control.
 
 ## Questions
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "develop": "hugo server -s ./exampleSite/",
+    "build:example": "hugo -s ./exampleSite/",
     "format": "prettier ./ --write"
   },
   "husky": {


### PR DESCRIPTION
Fixes https://github.com/jakewies/hugo-theme-codex/issues/69.

## Changelog

- Add a `yarn build:example` script, which triggers a one-time rebuild of the example site
- Document usage of `yarn build:example` in `CONTRIBUTING.md`

