### PR TITLE
layouts: add text/css MIME type to stylesheets

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,7 +33,7 @@
   
   {{ range (slice $base_styles_opts $custom_styles_opts) }}
     {{ $style := resources.Get .src | resources.ExecuteAsTemplate .dest $current_page | toCSS | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}"/>
+    <link type="text/css" rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}"/>
   {{ end }}
   
   {{ range .AlternativeOutputFormats }} 


### PR DESCRIPTION
With the `X-Content-Type-Options: "nosniff"` header set, stylesheet inclusions without the correct MIME type will be rejected by the browser.
