### PR TITLE
Twitter Meta Tags

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -37,6 +37,10 @@ copyright = "© {year}"
   #   "Twitter", "GitHub", "Email", "Facebook", "GitLab", "Instagram", "LinkedIn", "YouTube"
   iconTitles = ["Twitter", "GitHub"]
 
+  # Metadata for Twitter cards, defaults to params.twitter
+  # twitterSite = "@<your handle>"
+  # twitterAuthor = "@<your handle>"
+
 # This disables Hugo's default syntax highlighting in favor
 # of prismjs. If you wish to use Hugo's default syntax highlighting
 # over prismjs, remove this. You will also need to remove the prismjs

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,10 +16,9 @@
   {{ if isset .Site.Params "twitter" }}
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="{{ .Title }}" />
-  <meta name="twitter:description" content="{{ if .IsHome }}{{ htmlEscape .Site.Params.description }}{{ else }}{{ htmlEscape .Description }}{{ end }}"
-  />
-  <meta name="twitter:site" content="@{{ .Site.Params.twitter }}" />
-  <meta name="twitter:creator" content="@{{ .Site.Params.twitter }}" />
+  <meta name="twitter:description" content="{{ if .IsHome }}{{ htmlEscape .Site.Params.description }}{{ else }}{{ htmlEscape .Description }}{{ end }}"/>
+  <meta name="twitter:site" content="{{ .Site.Params.twitterSite | default .Site.Params.twitter }}" />
+  <meta name="twitter:creator" content="{{ .Site.Params.twitterCreator | default .Site.Params.twitter }}" />
   {{ end }}
 
   <link rel="shortcut icon" type="image/png" href="/favicon.ico" />


### PR DESCRIPTION
As discussed in #82 this adds correct support for the meta tags `twitter:creator` and `twitter:site`.
Exact details for why can be found here https://github.com/jakewies/hugo-theme-codex/issues/82#issue-657111646

It handles users not setting the new config values `twitterCreator` and `twitterSite` by falling back to the current behaviour of using `twitter` in both places.

It is imperfect, because it will only render meta tags if the config contains `twitter`. I think we can assume anyone wanting twitter metadata for creator and site will display the twitter link - therefore enabling this along the way.

Long term I would like to decouple meta tags from the social icons and introduce the ability to change them per post.
Not limited to the two twitter tags changed here.

Resolves #82