### PR TITLE
nav: fix aria attributes

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,4 +1,4 @@
-<nav class="nav" role="navigation">
+<nav class="nav" id="navigation">
   <ul class="nav__list">
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}


### PR DESCRIPTION
Lighthouse reports that the aria-controls attribute has an invalid value[1]. This
patch resolves it, fixing the lighthouse score[2].

1: https://github.com/msfjarvis/msfjarvis.dev/suites/933117726/artifacts/11488586
2: https://github.com/msfjarvis/msfjarvis.dev/suites/933157898/artifacts/11489135

This leaves one final issue in the accessibility section, the contrast of the username
text on the main page.
