### PR TITLE
docs: Use iconOrder when stating desired icon order

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also create additional social icons by:
       # ...
       reddit = "<url to your reddit>"
    
-      iconTitles = ["Reddit"]
+      iconOrder = ["Reddit"]
    ```
 
 Make sure that the icon title must match the icon's file name. If the title contains more than one word, say "My Awesome Site",

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -35,7 +35,7 @@ copyright = "© {year}"
   # Titles for your icons (shown as tooltips), and also their display order.
   # Currently, these icons are supported: 
   #   "Twitter", "GitHub", "Email", "Facebook", "GitLab", "Instagram", "LinkedIn", "YouTube"
-  iconTitles = ["Twitter", "GitHub"]
+  iconOrder = ["Twitter", "GitHub"]
 
   # Metadata for Twitter cards, defaults to params.twitter
   # twitterSite = "@<your handle>"


### PR DESCRIPTION
While the README was updated in #91 to use `iconOrder` instead of `iconTitles`, the example site config was left unchanged.