### PR TITLE
Allow for omitting date on post

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,8 +10,7 @@
         <div class="post">
           <header class="post__header">
             <h1 id="post__title">{{.Title}}</h1>
-            <time datetime="{{ .Date }}" class="post__date"
-            >{{ .Date.Format $dateFormat }}</time>
+            {{ if .Date }}<time datetime="{{ .Date }}" class="post__date">{{ .Date.Format $dateFormat }}</time> {{ end }}
           </header>
           <article class="post__content">
               {{ partial "anchored-headings.html" .Content }}


### PR DESCRIPTION
Previously, all posts had to show a date. If the `date:` attribute was removed from the md file, then something like "0000 Jan 01" would default. 

This is use for static pages that are not part of the blog structure, like a separate "about" or "contact" page.