### PR TITLE
docs: Document showPageTitleInTOC in README.md and config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ toc: false
 
 The frontmatter above is the default for a new post, but all values can be changed.
 
+### Configuring Table of Contents in blog posts
+
+To display post title in Table of Contents in blog posts, set `showPageTitleInTOC`
+to `true` in the `[params]` section of `config.toml`.
+
+```toml
+# config.toml
+
+[params]
+  # ...
+  showPageTitleInTOC = true
+```
+
 ### Adding a new section menu
 
 In your site's `config.toml`, add a new menu definition for say, "photos":

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -41,6 +41,9 @@ copyright = "© {year}"
   # twitterSite = "@<your handle>"
   # twitterAuthor = "@<your handle>"
 
+  # Set to true to display page title in table of contents in blog posts.
+  showPageTitleInTOC = false
+
 # This disables Hugo's default syntax highlighting in favor
 # of prismjs. If you wish to use Hugo's default syntax highlighting
 # over prismjs, remove this. You will also need to remove the prismjs


### PR DESCRIPTION
This PR documents the `showPageTitleInTOC` site param introduced in #10. Let me know if anything has to be changed.