### PR TITLE
layouts: Add markdown render hook to open links in new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,4 @@
+<a href="{{ .Destination | safeURL }}" {{ with .Title}} title="{{ . }}" {{ end }}
+  {{ if strings.HasPrefix .Destination "mailto" }} target="_blank" {{ end }}
+  {{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noreferrer noopener" {{ end }}
+>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
As of now, clicking on links opens them in the same tab. This patch adds a markdown render hook to open links in a new tab. 

This only works on Hugo v0.62.0 and above.

[Relevant docs page](https://gohugo.io/getting-started/configuration-markup/#markdown-render-hooks)