### PR TITLE
Fix browse-by-tag link

### DIFF
--- a/layouts/partials/browse-by-tag.html
+++ b/layouts/partials/browse-by-tag.html
@@ -1,7 +1,7 @@
 <ul class="tags__list">
   {{ range $tag, $value := $.Site.Taxonomies.tags }}
   <li class="tag__item">
-    <a class="tag__link" href="{{ "/tags/" | relLangURL}}{{ $tag | urlize }}">{{ $tag | urlize }} ({{ len $value }})</a>
+    <a class="tag__link" href="{{ "/tags/" | relLangURL}}{{ $tag | urlize }}/">{{ $tag | urlize }} ({{ len $value }})</a>
   </li>
   {{ end }}  
 </ul>


### PR DESCRIPTION
When browsing bt tags, it shows links to tag without `/`. For example, when browsing the blog page, the link on the side shows `http://localhost:1313/tags/kubernetes` and gives me 404 error page.

In this PR, the link should show `http://localhost:1313/tags/kubernetes/`.