### PR TITLE
Extract favicon into a partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
   <meta name="twitter:creator" content="{{ .Site.Params.twitterCreator | default .Site.Params.twitter }}" />
   {{ end }}
 
-  <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
+  {{ partial "favicon.html" }}
 
   <!-- Styles -->
   {{ block "styles" . }} {{ end }} <!-- Get "style_opts" variable from "styles" block -->

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,0 +1,1 @@
+<link rel="shortcut icon" type="image/png" href="/favicon.ico" />


### PR DESCRIPTION
#46

- Backwards compatible with previous implementation
- Consumers can define their own favicon in parital, depending on their
  preference of render / source