### PR TITLE
Remove broken instagram_simple shortcode

### DIFF
--- a/exampleSite/content/blog/rich-content.md
+++ b/exampleSite/content/blog/rich-content.md
@@ -12,11 +12,6 @@ toc: false
 
 Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
 
-## Instagram Simple Shortcode
-
-{{< instagram_simple BGvuInzyFAe hidecaption >}}
-
-
 ## YouTube Privacy Enhanced Shortcode
 
 {{< youtube ZJthWmvUzzc >}}


### PR DESCRIPTION
I noticed that `yarn develop` is failing based on an unreachable endpoint for the Instagram shortcode. 

```yarn run v1.22.5
$ hugo server -s ./exampleSite/
Start building sites …
ERROR 2020/11/21 23:21:22 Failed to get JSON resource "https://api.instagram.com/oembed/?url=https://www.instagram.com/p/BGvuInzyFAe/&amp;maxwidth=640&amp;omitscript=true": Failed to retrieve remote file: Bad Request
If you feel that this should not be logged as an ERROR, you can ignore it by adding this to your site config:
ignoreErrors = ["error-remote-getjson"]
Built in 766 ms
Error: Error building site: logged 1 error(s)
error Command failed with exit code 255.
info Visit https://yarnpkg.com/en/docs/cli/
```

After some light digging it appears that Instagram deprecated their API and this shortcode is broken for an indeterminate amount of time with no fix in the immediate future. The simplest solution for this project would be to remove mention of it from the demo site. 

Hugo Project: 
* https://github.com/gohugoio/hugo/issues/7879 
* https://github.com/gohugoio/hugoDocs/commit/57c1d1a67b9da5ba8ad5151d464f3fd7a21a24d8 


