### PR TITLE
Update MediaType for 0.82

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
   {{ end }}
   
   {{ range .AlternativeOutputFormats }} 
-  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.Suffix .Permalink $.Site.Title | safeHTML }} 
+  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.FirstSuffix.Suffix .Permalink $.Site.Title | safeHTML }} 
   {{ end }} 
   {{ block "links" . }} {{ end }}
   {{ partial "seo-schema.html" .}}


### PR DESCRIPTION
The Hugo 0.82 release moved `MediaType.Suffix` to be `MediaType.FirstSuffix.Suffix`  This PR makes that change in hugo-theme-codex/layouts/_default/baseof.html