### PR TITLE
layouts: update baseof.html to use FullSuffix.Suffix instead

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
   {{ end }}
   
   {{ range .AlternativeOutputFormats }} 
-  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.Suffix .Permalink $.Site.Title | safeHTML }} 
+  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.FirstSuffix.Suffix .Permalink $.Site.Title | safeHTML }} 
   {{ end }} 
   {{ block "links" . }} {{ end }}
   {{ partial "seo-schema.html" .}}


### PR DESCRIPTION
As per Hugo v0.82.0 onwards, the Suffix and FullSuffix on media.Type is
deprecated (see this [commit]) to make it comparable. Therefore,
running hugo commands will result in an error.

This commit fixes the issue according to the new media.Type struct
definitions.

[commit]:
https://github.com/gohugoio/hugo/commit/ba1d0051b44fdd242b20899e195e37ab26501516