### PR TITLE
fix(social-icons): "rel" attribute with multiple values in links

### DIFF
--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -5,9 +5,13 @@
   {{ range $icons }}
     {{ $icon := anchorize . }} 
     {{ if isset $currentPage.Site.Params $icon }}
-      <a class="social-icons__link" rel="me" title="{{ . }}"
-         href="{{ index $currentPage.Site.Params $icon }}"
-         target="_blank" rel="noopener">
+      <a
+        class="social-icons__link"
+        title="{{ . }}"
+        href="{{ index $currentPage.Site.Params $icon }}"
+        target="_blank"
+        rel="me noopener"
+      >
         <div class="social-icons__icon" style="background-image: url('{{print "svg/" $icon ".svg" | absURL}}')"></div>
       </a>
     {{ end }}


### PR DESCRIPTION
The `<a>` tag of social icons had two `rel` attributes, which didn't work — only the first one was kept. Instead of using the `rel` attribute twice with different values, we want to use it once with two values.