### PR TITLE
Add FirstSuffix to MediaType for Hugo v0.82 and bump minimum version of Hugo to 0.82

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
   {{ end }}
   
   {{ range .AlternativeOutputFormats }} 
-  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.Suffix .Permalink $.Site.Title | safeHTML }} 
+  {{ printf `<link rel="%s" type="%s+%s" href="%s" title="%s" />` .Rel .MediaType.Type .MediaType.FirstSuffix.Suffix .Permalink $.Site.Title | safeHTML }} 
   {{ end }} 
   {{ block "links" . }} {{ end }}
   {{ partial "seo-schema.html" .}}

--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "A minimal blog theme for hugo"
 homepage = "https://github.com/jakewies/hugo-theme-codex"
 tags = ["website", "starter", "blog"]
 features = ["blog"]
-min_version = "0.72.0"
+min_version = "0.82.0"
 
 [author]
   name = "Jake Wiesler"


### PR DESCRIPTION
As per #166 but with bumped minimum version added as that PR is old but I think this should to be added ASAP as breaking on new Hugo installs.

### Problem

On a default install of the theme into a new vanilla Hugo site the build fails with errors:

<pre><font color="#CC0000"><b>ERROR</b></font> 2021/07/20 10:19:05 render of &quot;taxonomy&quot; failed: <font color="#06989A"><b>&quot;/home/test/themes/hugo-theme-codex/layouts/_default/baseof.html:39:97&quot;</b></font>: execute of template failed: template: _default/list.html:39:97: executing &quot;_default/list.html&quot; at &lt;.MediaType.Suffix&gt;: can&apos;t evaluate field Suffix in type media.Type
<font color="#CC0000"><b>ERROR</b></font> 2021/07/20 10:19:05 render of &quot;taxonomy&quot; failed: <font color="#06989A"><b>&quot;/home/test/themes/hugo-theme-codex/layouts/_default/baseof.html:39:97&quot;</b></font>: execute of template failed: template: _default/list.html:39:97: executing &quot;_default/list.html&quot; at &lt;.MediaType.Suffix&gt;: can&apos;t evaluate field Suffix in type media.Type
Error: Error building site: failed to render pages: render of &quot;home&quot; failed: <font color="#06989A"><b>&quot;/home/test/themes/hugo-theme-codex/layouts/_default/baseof.html:39:97&quot;</b></font>: execute of template failed: template: index.html:39:97: executing &quot;index.html&quot; at &lt;.MediaType.Suffix&gt;: can&apos;t evaluate field Suffix in type media.Type
</pre>

### What's been done

The Hugo 0.82 release moved `MediaType.Suffix` to be `MediaType.FirstSuffix.Suffix`. This PR adds `FirstSuffix` in hugo-theme-codex/layouts/_default/baseof.html

And also bump min version of Hugo to 0.82 as adding `FirstSuffix` probably breaks builds on older versions of Hugo but at least they'll get a compatibility warning on build: `Module "hugo-theme-codex" is not compatible with this Hugo version`.