### PR TITLE
Update _nav.scss to left-align the navbar

### DIFF
--- a/assets/scss/partials/_nav.scss
+++ b/assets/scss/partials/_nav.scss
@@ -1,6 +1,7 @@
 @import "burger";
 
 .nav {
+  padding-left:40px;
   font-size: 16px;
   position: fixed;
   display: flex;
@@ -29,7 +30,7 @@
 }
 
 .nav__list {
-  text-align: right;
+  text-align: left;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -64,6 +65,7 @@
 }
 
 .nav__list a {
+
   color: $grey;
   text-decoration: none;
   font-size: 2em;


### PR DESCRIPTION
The vertical navbar which has the style `_nav.scss` was right-aligned. I left-aligned it by adding padding to the `.nav` class and changing `text-align: right;` to `text-align: left;`.

* Before:

![image](https://user-images.githubusercontent.com/54571275/136709056-c9280cc6-7738-4ee5-bdac-26e6b3b61e2d.png)

* After:

![image](https://user-images.githubusercontent.com/54571275/136709067-3804e856-9d03-4cac-8c5a-27a34cef7b2b.png)


In my opinion, this looks more visually appealing.