### PR TITLE
Change to support Google Analytics v4

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
   {{ partial "seo-schema.html" .}}
 
   {{- if not .Site.IsServer -}}
-      {{ template "_internal/google_analytics_async.html" . }}
+      {{ template "_internal/google_analytics.html" . }}
   {{- end -}}
 </head>
 


### PR DESCRIPTION
Google analytics v4 use different js code, template "google_analytics_async.html" don't support analytics v4.
Change template to "google_analytics.html", this template determine analytics version and render right js code.