### PR TITLE
Make home page subheading optional.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,9 +11,11 @@
     {{ if isset .Params "handle" }}
     <span class="handle">@{{ .Params.handle }}</span>
     {{ end }}
+    {{ if isset .Params "subheading" }}
     <h2>
       {{ .Params.subheading }}
     </h2>
+    {{ end }}
     <!-- Replace MEEEEE -->
 
     {{ partial "social-icons.html" .}}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -4,11 +4,10 @@
 
 {{ define "main" }}
   {{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
-  {{ $blogDir := .Site.Params.blogDir | default "/blog" }}
 
   <div class="post-list__container">
     <div class="tag__header">
-      <a href="{{ $blogDir }}">{{ i18n "all_posts" }}</a><span class="separator">/</span>
+      <a href="/blog">{{ i18n "all_posts" }}</a><span class="separator">/</span>
       <h1 class="tag__term">{{ .Title }}</h1>
     </div>
     <ul class="post-list">

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -4,10 +4,11 @@
 
 {{ define "main" }}
   {{ $dateFormat := .Site.Params.dateFormat | default "Jan 2 2006" }}
+  {{ $blogDir := .Site.Params.blogDir | default "/blog" }}
 
   <div class="post-list__container">
     <div class="tag__header">
-      <a href="/blog">{{ i18n "all_posts" }}</a><span class="separator">/</span>
+      <a href="{{ $blogDir }}">{{ i18n "all_posts" }}</a><span class="separator">/</span>
       <h1 class="tag__term">{{ .Title }}</h1>
     </div>
     <ul class="post-list">


### PR DESCRIPTION
If the subheading param in the content/index is not set, the h2 element in the rendered html is left empty, but remains on the page. This adds a check to the subheading similar to the handle right above it.