### PR TITLE
fix(layouts/_default/baseof.html):fix google_analytics bug

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,7 +42,7 @@
   {{ partial "seo-schema.html" .}}
 
   {{- if not .Site.IsServer -}}
-      {{ template "_internal/google_analytics_async.html" . }}
+      {{ template "_internal/google_analytics.html" . }}
   {{- end -}}
 </head>
 


### PR DESCRIPTION
In the new version of Hugo, the old google_analytics_async.html has been deprecated and replaced with the new { template "_internal/google_analytics.html" . }.